### PR TITLE
KOI Naming Convention Update: Support for Property-Based Naming

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,6 +3,11 @@
 Thank you for your interest in contributing to the **Knowledge Organization Infrastructure (KOI)**! This document outlines how you can meaningfully contribute to KOI governance, naming conventions, and semantic standards.
 
 ---
+👐 Who Can Contribute?
+
+Anyone! You don’t need to be a developer or GitHub expert. If you’re creating meaningful documents—like a plan, decision, proposal, or dataset—you can contribute to KOI.
+
+This includes scientists, policy designers, technologists, and community leaders.
 
 ## 👐 How to Contribute
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,6 +32,8 @@ To propose a new KOI prefix, type, relevance tier, or naming convention:
 3. **Submit your proposal as a Pull Request (PR)** to this repository.
     - Clearly summarize your changes and reasoning in the PR description.
     - Indicate whether your change is major, minor, or patch according to semantic versioning guidelines.
+  
+   > 🔍 Tip: When piloting new KOI objects in Notion or similar tools, consider separating the full KOI name into structured properties. This supports better searchability, clarity, and integration with AI tools and metadata crawlers.
 
 ---
 
@@ -73,8 +75,21 @@ Clearly communicate the impact of your proposal using semantic versioning in you
 - `vX.0.0`: Major conceptual shifts (introducing entirely new prefixes, tiers, or fundamental restructuring)
 - `vX.Y.0`: Meaningful updates or expansions of existing conventions
 - `vX.Y.Z`: Editorial, non-conceptual clarifications, or minor refinements
+-  You may also specify whether the KOI object uses `single-string` or `property-based` naming in your PR.
+
 
 Include clear explanations of your semantic versioning choices in your PR description.
+
+## 📝 Format Declaration Tip
+
+When submitting a new KOI object or naming schema, please specify whether you're using:
+
+- a **single-string format**  
+  (e.g., `core.memo.token-strategy.v1.0.0` as the title), or  
+- a **property-based format**  
+  (e.g., a clean human-readable title plus metadata fields like `KOI Name`, `Type`, `Version`, etc., in Notion, YAML, or JSON).
+
+This helps reviewers understand the intended usage context and ensures consistency across different tools and agents in the KOI ecosystem.
 
 ---
 

--- a/KOI.regen-naming-convention-manifesto.v1.0.0.md
+++ b/KOI.regen-naming-convention-manifesto.v1.0.0.md
@@ -32,11 +32,10 @@ This document defines the semantic naming convention used across the KOI (Knowle
 
 ---
 
-## **Purpose**
+## **Audience**
 
-This document defines the semantic naming convention used across the KOI (Knowledge Organization Infrastructure) system stewarded by Regen Network Development, PBC. It articulates the reasons for using this naming convention, the structure itself, the upgrade process, and principles to guide when and how to expand the namespace. The intention is to foster collective coherence, support semantically legible digital institutions, and align naming practices with Regen’s deep commitments to regeneration, trust, and clarity.
+This guide is for anyone contributing knowledge to Regen Network — whether you're a scientist, organizer, developer, or policy thinker. You don’t need to be technical to use this guide. You just need to care about naming things clearly so others can find and reuse them.
 
----
 
 ## **Current Structure**
 
@@ -81,24 +80,24 @@ The current KOI naming system follows this schema:
 ---
 ## 🧠 Alternate Format: Semantic Properties
 
-In addition to embedding KOI metadata into a single string (e.g., `core.memo.q2-sprint.v1.0.0`), KOI objects can now use *distributed properties* in tools that support it (e.g., Notion databases, YAML frontmatter, JSON-LD).
+In addition to embedding KOI metadata into a single string (e.g., `core.memo.q2-sprint-strategy.v1.0.0`), KOI objects can use **distributed properties** in tools that support it (like Notion, YAML frontmatter, or JSON).
 
-Example in Notion:
+### Example in Notion:
+
 | Property    | Value                                                  |
 |-------------|--------------------------------------------------------|
-| KOI Name    | `core.objective.rnd-foundation-sprint.v2025-Q2.v0.1.4` |
+| KOI Name    | `core.objective.q2-commons-activation.v2025-Q2.v1.0.0` |
 | Type        | `core.objective`                                       |
 | Relevance   | `core`                                                 |
-| Version     | `v2025-Q2.v0.1.4`                                       |
+| Version     | `v2025-Q2.v1.0.0`                                       |
 | Status      | `active`                                               |
 
-**This enables:**
+**Benefits:**
 - Machine-readability for AI agents and future KOI indexers
-- Human usability via clean, expressive titles
-- Flexible rendering across platforms
+- Human usability via clear titles
+- Structured search, sorting, and linking across platforms
 
-For practical examples, see: [`docs/semantic-naming-properties.md`](./docs/semantic-naming-properties.md)
-
+➡ See: [`docs/semantic-naming-properties.md`](./docs/semantic-naming-properties.md)
 
 ## **Rationale: Why This Naming Convention Exists**
 
@@ -170,25 +169,13 @@ You **may want to add a new prefix or type** if:
 
 * You want to create a `decision log`, `experimental module`, or `archived work` and it doesn’t clearly fit `core`, `relevant`, or `background`
 
-### **Recent Example: `exploratory.` (Proposed)**
+## 🔍 Examples for Non-Coders
 
-In April 2025, the team considered introducing:
+| Human-Friendly Title             | KOI Name                                               |
+|----------------------------------|--------------------------------------------------------|
+| Earth Stewardship Q2 Plan        | `core.plan.earth-stewardship.v2025-Q2.v1.0.0`          |
+| Biodiversity Credit Metrics (Draft) | `exploratory.notes.biodiversity-metrics.v0.2.1`     |
 
-* `exploratory.` for early-stage ideation that is neither background nor relevant yet
-
-* `archived.` for deprecated docs
-
-* `decision.` to snapshot cross-team agreements
-
-This was proposed in:
-
-```
-meta.reflection.koi-schema-expansion.v0.1.0
-```
-
-…and piloted informally in DAU and Commons naming. The result was increased semantic clarity for pre-synthesis docs.
-
----
 
 ## **Closing Reflection**
 
@@ -206,17 +193,8 @@ To name is to tend the garden of meaning. We name not just to label, but to **cr
 
 ## **Draft KOI Naming Convention Changelog**
 
-This section tracks approved changes to the KOI naming schema over time.
-
-| Version | Date | Change Summary | Author(s) |
-| ----- | ----- | ----- | ----- |
-| 1.0.0 | 2025-04-07 | Initial release with core, relevant, background relevance tiers \+ vX.Y.Z system | RND PBC Retreat Team |
-| 1.1.0 | *TBD* | (Proposed) Add `decision.`, `archived.`, `experimental.` prefixes | *Pending approval* |
-| 1.2.0 | *TBD* | (Optional) Refactor or clarify `readme.` usage and folder-scoped naming | *Pending* |
-
-To propose changes:
-
-* Create a new versioned document (e.g. `meta.reflection.koi-schema-expansion.vX.Y.Z`)  
-* Pilot and review  
-* Record approved changes here
+| Version | Date       | Change Summary                                                      | Author(s)           |
+|---------|------------|----------------------------------------------------------------------|---------------------|
+| 1.0.0   | 2025-04-07 | Initial release with core, relevant, background relevance tiers + vX.Y.Z system | RND PBC Retreat Team |
+| 1.1.0   | 2025-04-16 | Added property-based format guidance (Notion, GDocs, GitHub)         | Regen Coordination  |
 

--- a/KOI.regen-naming-convention-manifesto.v1.0.0.md
+++ b/KOI.regen-naming-convention-manifesto.v1.0.0.md
@@ -79,6 +79,26 @@ The current KOI naming system follows this schema:
   * `Z` \= editorial or structural update only
 
 ---
+## 🧠 Alternate Format: Semantic Properties
+
+In addition to embedding KOI metadata into a single string (e.g., `core.memo.q2-sprint.v1.0.0`), KOI objects can now use *distributed properties* in tools that support it (e.g., Notion databases, YAML frontmatter, JSON-LD).
+
+Example in Notion:
+| Property    | Value                                                  |
+|-------------|--------------------------------------------------------|
+| KOI Name    | `core.objective.rnd-foundation-sprint.v2025-Q2.v0.1.4` |
+| Type        | `core.objective`                                       |
+| Relevance   | `core`                                                 |
+| Version     | `v2025-Q2.v0.1.4`                                       |
+| Status      | `active`                                               |
+
+**This enables:**
+- Machine-readability for AI agents and future KOI indexers
+- Human usability via clean, expressive titles
+- Flexible rendering across platforms
+
+For practical examples, see: [`docs/semantic-naming-properties.md`](./docs/semantic-naming-properties.md)
+
 
 ## **Rationale: Why This Naming Convention Exists**
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 **Repository Status:** Active Development  
 **Lead Maintainer:** Gregory Landua  
-**Last Updated:** April 14, 2025
+**Last Updated:** April 16, 2025
 
 ---
 
@@ -13,15 +13,19 @@ Welcome to the **KOI (Knowledge Organization Infrastructure) Governance Reposito
 
 KOI is our collective infrastructure for creating coherent, transparent, and actionable knowledge objects within Regen Network. By maintaining semantic clarity, we enable decentralized teams, AI agents, and community participants to collaborate meaningfully.
 
+> 💡 **New to KOI or GitHub?**  
+> This repo is for everyone — not just coders! If you’re a scientist, community builder, designer, or strategist, KOI helps you contribute documents that are clear, consistent, and findable. Start with our [Semantic Naming via Properties guide](./docs/semantic-naming-properties.md).
+
 ---
 
 ## 📌 Key Documents
 
-| Document | Purpose |
-| -------- | ------- |
-| [`KOI.naming-convention-manifesto.v1.0.0.md`](./KOI.regen-naming-convention-manifesto.v1.0.0.md) | Defines the KOI semantic naming schema, versioning practices, and governance process. |
-| [`CONTRIBUTING.md`](./CONTRIBUTING.md) | Explains how to propose, pilot, and ratify changes to the KOI naming schema. |
-| [`changelog.md`](./changelog.md) | Tracks all approved changes and updates to the naming conventions. |
+| 📄 Document | 🧭 Purpose |
+|------------|------------|
+| [`KOI.naming-convention-manifesto.v1.0.0.md`](./KOI.regen-naming-convention-manifesto.v1.0.0.md) | Defines the KOI naming system and versioning rules |
+| [`CONTRIBUTING.md`](./CONTRIBUTING.md) | How to propose naming conventions or contribute documents |
+| [`changelog.md`](./changelog.md) | Tracks all changes and updates to KOI naming standards |
+| [`semantic-naming-properties.md`](./docs/semantic-naming-properties.md) | How to use Notion, GDocs, or GitHub with KOI structured naming |
 
 ---
 
@@ -30,11 +34,12 @@ KOI is our collective infrastructure for creating coherent, transparent, and act
 ```
 KOI-governance/
 │
-├── README.md                          # You are here
+├── README.md
 ├── KOI.naming-convention-manifesto.v1.0.0.md
-├── CONTRIBUTING.md                    # Contribution guidelines (soon)
-├── changelog.md                       # Record of changes (soon)
-└── docs/                              # Additional documentation or semantic assets
+├── CONTRIBUTING.md
+├── changelog.md
+├── docs/
+│   └── semantic-naming-properties.md
 ```
 
 ---
@@ -43,12 +48,10 @@ KOI-governance/
 
 We enthusiastically welcome contributions from everyone! Here's how you can help:
 
-- **Review the KOI Manifesto**: Familiarize yourself with the current naming conventions.
-- **Open an Issue**: Suggest new prefixes, types, or relevance tiers.
-- **Create a Pull Request**: Propose changes formally with your semantic reasoning and pilots.
-- **Participate in Governance Discussions**: Join our regular calls or async forums to discuss proposals and feedback.
-
-Stay tuned for the full [`CONTRIBUTING.md`](./CONTRIBUTING.md) file for detailed instructions.
+- **Review the KOI Manifesto**: Understand how our naming system works.
+- **Use KOI Naming**: Apply it to any document you create for Regen Network.
+- **Propose Improvements**: Open issues or PRs to improve naming clarity or structure.
+- **Join the Conversation**: Attend KOI sync calls or participate in async discussions.
 
 ---
 
@@ -60,21 +63,34 @@ Stay tuned for the full [`CONTRIBUTING.md`](./CONTRIBUTING.md) file for detailed
 ```
 
 ### Relevance Levels
-- **`core`**: Fundamental, actively used, essential to strategic decisions.
-- **`relevant`**: Informative, actively cited, influential in ongoing work.
-- **`background`**: Contextual, supportive, historical, or ambient reference.
+- **`core`**: Foundational, widely used, and trusted.
+- **`relevant`**: Actively cited, helpful in ongoing work.
+- **`background`**: Informative, ambient, or historical.
 
 ### Object Types
-- **`memo`**: Structured strategic or operational documents.
-- **`analysis`**: Data-driven or qualitative deep dives.
-- **`notes`**: Informal or exploratory ideas and documentation.
-- **`decision`** *(proposed)*: Official organizational decisions.
-- **`readme`**: Canonical documentation for directories or patterns.
+- **`memo`**: Strategic or operational documents.
+- **`analysis`**: Data-driven or qualitative breakdowns.
+- **`notes`**: Informal, exploratory documentation.
+- **`decision`**: Records of formal decisions.
+- **`readme`**: Descriptive documentation of a folder or pattern.
 
 ### Semantic Versioning
 - `vX.0.0`: Major conceptual shifts
-- `vX.Y.0`: Minor, meaningful content updates
-- `vX.Y.Z`: Editorial, non-conceptual adjustments or clarifications
+- `vX.Y.0`: New content or moderate updates
+- `vX.Y.Z`: Minor or editorial changes
+
+---
+
+## 🧠 Property-Based Naming Format (New)
+
+When using modern tools like Notion, you can separate the KOI title and metadata:
+
+- **Human-friendly title**: e.g. `"Q2 Strategy – Commons Activation"`
+- **Properties**:
+  - KOI Name: `core.objective.q2-commons-activation.v2025-Q2.v1.0.0`
+  - Type, Version, Relevance, Status (stored in tool-native fields)
+
+➡ See: [`semantic-naming-properties.md`](./docs/semantic-naming-properties.md) for examples in Notion, GDocs, and GitHub
 
 ---
 
@@ -82,25 +98,9 @@ Stay tuned for the full [`CONTRIBUTING.md`](./CONTRIBUTING.md) file for detailed
 
 Implementing clear, semantic naming isn't trivial—it's foundational. It:
 
-- **Facilitates trust and clarity** within distributed teams and collaborators.
-- **Supports adaptive governance** and decision-making.
-- **Empowers human-AI collaboration** through semantic precision.
+- Facilitates trust and clarity across distributed teams
+- Enables decentralized governance and documentation
+- Supports AI and agent-based coordination with structured knowledge
 
-Let's tend our shared garden of knowledge and coherence together.
-
----
-
-## 📅 Upcoming Steps
-
-- Finalize and publish the contribution guidelines (`CONTRIBUTING.md`).
-- Begin accepting and reviewing community pull requests.
-- Host a community kickoff call to onboard contributors.
-
----
-
-## 🙌 Contact
-
-Questions? Reach out directly to Gregory or open an issue in this repository.
-
-Thank you for nurturing our collective coherence and stewardship!
+Let’s tend our shared garden of meaning, one clear name at a time. 🌱
 

--- a/changelog.md
+++ b/changelog.md
@@ -4,73 +4,71 @@ This changelog tracks all officially ratified changes and updates to the KOI (Kn
 
 ---
 
+## ⏳ Timeline Overview
+
+- ✅ 2025-04-07: v1.0.0 – Initial KOI naming schema established
+- ✅ 2025-04-16: v1.1.0 – Added property-based KOI naming format for Notion, GDocs, GitHub
+
+---
+
 ## 🗂️ Version History
 
-### [v1.0.0] - 2025-04-07
+### [v1.1.0] - 2025-04-16 ✅
+
+#### New Feature: Property-Based KOI Naming
+
+- KOI objects may now be expressed using **semantic metadata fields** in tools like Notion, Google Docs, and GitHub
+- This includes separating the `title` from properties such as `KOI Name`, `Type`, `Version`, `Status`, etc.
+- Improves searchability, machine parsing, and human readability
+- See new guide: [`docs/semantic-naming-properties.md`](./docs/semantic-naming-properties.md)
+
+### [v1.0.0] - 2025-04-07 ✅
 
 #### Initial Release
+
 - Established initial semantic naming convention:
   ```
   [relevance].[type].[subject].vX.Y.Z
   ```
 
 #### Relevance Tiers
-- **`core.`** - Canonical, foundational documents.
-- **`relevant.`** - Influential, actively cited documentation.
-- **`background.`** - Contextual, historical, supportive material.
+- **`core.`** – Canonical, foundational documents
+- **`relevant.`** – Actively cited or influential docs
+- **`background.`** – Supportive, ambient, or historical material
 
 #### Object Types
-- `memo` - Strategic or operational documents.
-- `analysis` - Detailed quantitative or qualitative breakdowns.
-- `notes` - Informal ideas and documentation.
-- `readme` - Canonical directory and pattern documentation.
+- `memo` – Strategic or operational thinking
+- `analysis` – Quantitative/qualitative breakdowns
+- `notes` – Raw or exploratory ideas
+- `readme` – Canonical directory or pattern documentation
 
 #### Semantic Versioning Guidelines
-- `vX.0.0`: Major conceptual shifts or introductions.
-- `vX.Y.0`: Minor, meaningful expansions or adjustments.
-- `vX.Y.Z`: Editorial or minor clarifications.
+- `vX.0.0`: Major conceptual shifts or naming structure changes
+- `vX.Y.0`: Additions or updates to existing tiers/types
+- `vX.Y.Z`: Editorial or minor clarifications
 
 #### Governance Process
-- Defined the process for proposing, piloting, and ratifying naming convention changes via GitHub PRs and weekly governance calls.
+- Proposed via markdown docs and GitHub PRs
+- Piloted and discussed in KOI syncs
+- Approved by consensus during governance calls
 
 ---
 
-## 🔜 Upcoming Proposed Changes
+## ✍️ How to Update This Changelog
 
-The following changes have been proposed and are pending further discussion, piloting, and formal approval:
-
-### [v1.1.0] - 2025-04-16 *(proposed)*
-
-#### New Feature: Property-Based KOI Naming
-
-- KOI objects may now be expressed using *semantic metadata fields* in rich tools (e.g., Notion).
-- This includes separating the `title` from metadata fields: `KOI Name`, `Type`, `Version`, etc.
-- Improves searchability, machine parsing, and human readability.
-- Documented in `docs/semantic-naming-properties.md`
-
-
-### [v1.1.0] *(proposed)*
-- Add new object types:
-  - `decision` – Official records of organizational decisions.
-  - `experimental` – Early-stage or temporary exploratory content.
-- Add relevance tier:
-  - `exploratory` – Clearly distinguishes ideation from `background` and `relevant` tiers.
-
----
-
-## ✍️ How to Update this Changelog
-
-- Update this file after every officially ratified naming convention change.
-- Clearly list new versions at the top with detailed breakdowns of changes.
-- Maintain clear semantic versioning discipline in alignment with KOI guidelines.
+- Add new entries to the top of the list
+- Be concise but clear: what changed, why, and what version bump was made
+- Link related guides or proposals when possible
 
 ---
 
 ## 🤝 Contribution & Governance
 
-To propose changes or adjustments:
-- Submit a Pull Request (PR) following instructions in [`CONTRIBUTING.md`](./CONTRIBUTING.md).
-- Changes are reviewed and ratified during weekly governance calls.
+To propose changes:
+
+- Submit a Pull Request following [`CONTRIBUTING.md`](./CONTRIBUTING.md)
+- Include examples, reasoning, and whether the change is major, minor, or a patch
+- Attend a KOI sync call for live review
 
 Thank you for contributing to the clarity and coherence of KOI Governance!
 

--- a/changelog.md
+++ b/changelog.md
@@ -39,6 +39,16 @@ This changelog tracks all officially ratified changes and updates to the KOI (Kn
 
 The following changes have been proposed and are pending further discussion, piloting, and formal approval:
 
+### [v1.1.0] - 2025-04-16 *(proposed)*
+
+#### New Feature: Property-Based KOI Naming
+
+- KOI objects may now be expressed using *semantic metadata fields* in rich tools (e.g., Notion).
+- This includes separating the `title` from metadata fields: `KOI Name`, `Type`, `Version`, etc.
+- Improves searchability, machine parsing, and human readability.
+- Documented in `docs/semantic-naming-properties.md`
+
+
 ### [v1.1.0] *(proposed)*
 - Add new object types:
   - `decision` – Official records of organizational decisions.

--- a/docs/semantic-naming-properties.md
+++ b/docs/semantic-naming-properties.md
@@ -1,0 +1,86 @@
+# Semantic Naming via Properties
+
+KOI objects can now use **structured properties** (instead of embedding everything in the title) when tools support them. This enables both **human usability** and **machine interoperability**.
+
+---
+
+## 🧠 Why Properties Matter
+
+- Clear display titles help humans scan content.
+- Structured metadata fields enable search, sorting, and semantic indexing.
+- Prepares KOI for integration with agents, APIs, and graph-based storage systems.
+
+---
+
+## 🛠 Tool-by-Tool Implementation
+
+### 🟡 Notion
+
+Use a Notion Database to represent KOI Objects with structured properties:
+
+| Property    | Value                                                  |
+|-------------|--------------------------------------------------------|
+| Title       | Q2 Sprint Strategy – Regen Commons                     |
+| KOI Name    | core.objective.rnd-foundation-sprint.v2025-Q2.v0.1.4  |
+| Type        | core.objective                                         |
+| Relevance   | core                                                   |
+| Version     | v2025-Q2.v0.1.4                                        |
+| Status      | active                                                 |
+
+- **Search Tips**: Notion prioritizes title search. Use filters to query metadata.
+- **Linking**: Canonical versions can link to Google Docs, GitHub, or exported JSON.
+
+---
+
+### 🔵 Google Docs
+
+- Use full KOI name in **title** or include a metadata table at the top of the document.
+
+Example metadata block:
+```
+Title: Q2 Sprint Strategy – Regen Commons
+KOI Name: core.objective.rnd-foundation-sprint.v2025-Q2.v0.1.4
+Version: v2025-Q2.v0.1.4
+Type: core.objective
+Relevance: core
+Status: active
+```
+
+---
+
+### ⚪ GitHub
+
+- Use KOI naming in file and folder names.
+- Add metadata in frontmatter (for markdown files):
+
+```yaml
+---
+koi_name: core.objective.rnd-foundation-sprint.v2025-Q2.v0.1.4
+version: v2025-Q2.v0.1.4
+type: core.objective
+relevance: core
+status: active
+---
+```
+
+---
+
+## 🔍 Search & Retrieval Considerations
+
+| Tool        | Indexed Fields            | Best Practice                                     |
+|-------------|---------------------------|---------------------------------------------------|
+| Notion      | Title + properties        | Use filters for semantic queries                  |
+| GDocs       | Title + body              | Put KOI metadata near the top                     |
+| GitHub      | File/Folder + frontmatter | Embed metadata in filenames and YAML blocks       |
+
+---
+
+## 🌱 Looking Ahead
+
+These property-based formats prepare KOI for:
+- JSON-LD / RDF export
+- AI-assisted retrieval
+- Multi-agent coordination systems
+
+We name to create clarity. Structured properties help us grow semantic legibility for both humans and machines.
+


### PR DESCRIPTION
###  KOI Naming Convention Update: Support for Property-Based Naming

This PR updates the KOI Governance repo to reflect the newly suggested property-based naming pattern, which enables KOI objects to be expressed as structured metadata (rather than only as single-string names).

---

### ✅ Summary of Changes

- `KOI.naming-convention-manifesto.v1.0.0.md`  
  - Adds `Audience` section  
  - Adds guidance for property-based naming (e.g., in Notion, GitHub frontmatter)  
  - Includes examples for non-coders  
  - Clarifies changelog table (v1.1.0)

- `README.md`  
  - Adds reference to semantic-naming-properties guide  
  - Clarifies usage for non-technical contributors  

- `CONTRIBUTING.md`  
  - Adds `Format Declaration` section (single-string vs. property-based)  
  - Adds instructions for Notion / GDocs contributors  

- `changelog.md`  
  - Adds v1.1.0 entry (ratified property-based naming support)

- `docs/semantic-naming-properties.md`  
  - **New guide** for using KOI with Notion, Google Docs, and GitHub

---

### 🔁 Why This Matters

- Makes KOI easier to use for non-technical contributors  
- Prepares KOI for machine interoperability (semantic search, graph agents)  
- Aligns our naming system with real-world collaborative tools like Notion

---

Thanks to everyone stewarding this evolution. 🌀
