### PR TITLE
v1.2.0 — add spec/plan/overview/registry types, ledger anchoring, examples, bugfixes

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,7 +3,8 @@
 Thank you for your interest in contributing to the **Knowledge Organization Infrastructure (KOI)**! This document outlines how you can meaningfully contribute to KOI governance, naming conventions, and semantic standards.
 
 ---
-👐 Who Can Contribute?
+
+## 👐 Who Can Contribute?
 
 Anyone! You don’t need to be a developer or GitHub expert. If you’re creating meaningful documents—like a plan, decision, proposal, or dataset—you can contribute to KOI.
 

--- a/KOI.regen-naming-convention-manifesto.v1.2.0.md
+++ b/KOI.regen-naming-convention-manifesto.v1.2.0.md
@@ -1,0 +1,231 @@
+# KOI Regen Naming Convention Manifesto
+
+**Version:** 1.2.0
+**Status:** Active
+**Maintainer:** Gregory Landua
+**Last Updated:** 2026-04-21
+
+---
+
+## Purpose
+
+This document defines the canonical semantic naming conventions for KOI (Knowledge Organizing Infrastructure) objects within Regen Network. These conventions enable coherent coordination between distributed teams, AI agents, and community participants.
+
+---
+
+## Naming Structure
+
+```
+[relevance].[type].[subject].vX.Y.Z
+```
+
+### Examples
+
+```
+core.strategy.regen-os-overview.v0.1.0
+core.spec.regen-os-learning-subroutines.v0.1.0
+core.plan.regen-os-phase-delivery.v0.1.0
+core.registry.regen-os-artifact-registry.v0.1.0
+core.overview.regen-commons-current-state.v0.1.0
+relevant.analysis.distribution-moat-dual-framework.v1.0.0
+relevant.research.aimma-regulatory-landscape.v1.0.0
+background.notes.ecosystem-partner-landscape.v0.3.1
+```
+
+See [`examples/`](./examples/) for worked examples of each v1.2.0 type.
+
+---
+
+## Relevance Levels
+
+| Level | Meaning | Typical Use |
+|-------|---------|-------------|
+| `core` | Fundamental, actively used, essential to strategic decisions. | Active strategy docs, governance frameworks, canonical references. |
+| `relevant` | Informative, actively cited, influential in ongoing work. | Supporting analyses, partner-specific materials, active research. |
+| `background` | Contextual, supportive, historical, or ambient reference. | Archived decisions, historical context, exploratory notes. |
+
+---
+
+## Object Types
+
+### Original Types (v1.0.0)
+
+| Type | Description | When to Use |
+|------|-------------|-------------|
+| `memo` | Structured strategic or operational document. | Formal communication, position papers, internal proposals. |
+| `analysis` | Data-driven or qualitative deep dive. | Market analysis, deal modeling, technical evaluation. |
+| `notes` | Informal or exploratory ideas and documentation. | Meeting notes, brainstorms, working drafts. |
+| `decision` | Official organizational decision record. | Governance votes, strategic commitments, policy changes. |
+| `readme` | Canonical documentation for directories or patterns. | Repository docs, onboarding guides, system overviews. |
+
+### Expanded Types (v1.1.0)
+
+Codified in v1.1.0 from active Notion KOI Repo usage.
+
+| Type | Description | When to Use |
+|------|-------------|-------------|
+| `strategy` | Forward-looking strategic framework or business model. | GTM plans, business models, roadmaps, investment narratives. |
+| `docs` | Reference documentation, specifications, or guides. | Technical specs, API docs, process documentation, handbooks. |
+| `feedback` | Structured feedback on proposals, products, or processes. | Review responses, partner feedback, user research findings. |
+| `research` | Investigative or exploratory research output. | Market research, regulatory landscape scans, technology assessments. |
+| `press` | External-facing communications and media materials. | Blog posts, press releases, public statements, media briefs. |
+| `prompt` | AI prompt templates, agent configurations, or instruction sets. | System prompts, skill definitions, agent specs, prompt libraries. |
+| `transcript` | Meeting or conversation transcript, typically AI-generated. | Otter.ai transcripts, call recordings, interview records. |
+
+### Expanded Types (v1.2.0)
+
+The following types emerged from active use cases that had no clean home in v1.1.0. Each is grounded in a concrete RegenOS artifact or mainnet-anchored artifact; see [`examples/`](./examples/) for the worked pilots satisfying the CONTRIBUTING.md minimum-3-object pilot requirement.
+
+| Type | Description | When to Use | Pilot |
+|------|-------------|-------------|-------|
+| `spec` | Technical specification, agentic loop spec, pattern specification, or agent instruction template. | Agent loop definitions, pattern specs, schema specs, protocol specifications that aren't general `docs`. | `core.spec.regen-os-learning-subroutines.v0.1.0` |
+| `plan` | Phased execution plan with milestones, gates, and resource requirements. | Dogfood plans, discovery pipelines, phased delivery plans distinct from forward-looking `strategy`. | `core.plan.regen-os-phase-delivery.v0.1.0` |
+| `overview` | Canonical explainer of a system or domain at a point in time. | Top-level explainers that aren't directory entry points (`readme`) and aren't forward-looking (`strategy`). | `core.overview.regen-os-current-state.v0.1.0` |
+| `registry` | Meta-document that indexes or directories other knowledge objects. | Artifact registries, URL/RID maps, schema libraries, catalog indexes distinct from reference `docs`. | `core.registry.regen-os-artifact-registry.v0.1.0` |
+
+### Deprecated Types
+
+| Type | Status | Notes |
+|------|--------|-------|
+| Final Analysis | Deprecated — use `analysis` instead. | Was used in Notion KOI Repo as a status marker. Use `analysis` as the type and track completion status separately via the Status field. |
+
+---
+
+## Choosing Between Types
+
+When the distinction is ambiguous:
+
+- **memo vs strategy** — Memos communicate a position or proposal; strategies lay out a forward-looking plan with phases, milestones, or resource requirements.
+- **analysis vs research** — Analyses evaluate a specific question or decision; research explores a domain or landscape more broadly.
+- **docs vs readme** — Readmes are entry-point documentation for a specific directory or system; docs are standalone reference materials.
+- **docs vs spec** — Docs are general reference material; specs are precise definitions of a technical artifact, agent loop, or pattern intended to be implemented or executed against.
+- **docs vs registry** — Docs describe a thing; registries index many things. A registry's primary content is the index itself, not the content of what's indexed.
+- **strategy vs plan** — Strategy is the framework (why + what); plan is the execution sequence (when + who + gates). A strategy contains a plan; a plan operationalizes a strategy.
+- **readme vs overview** — Readmes are entry-points to a directory/repo (how to navigate this place); overviews are explainers of a system/domain (what this system is and how it works). A readme answers "start here"; an overview answers "what is this?"
+- **notes vs transcript** — Notes are human-authored (even if rough); transcripts are machine-generated or verbatim records.
+- **feedback vs memo** — Feedback responds to something specific; memos originate a position.
+
+---
+
+## Semantic Versioning
+
+KOI objects use semantic versioning to track conceptual evolution:
+
+| Version Component | Meaning | Example |
+|-------------------|---------|---------|
+| `vX.0.0` (major) | Fundamental conceptual shift, reframe, or restructure. | v1.0.0 → v2.0.0: complete rethinking of token utility model. |
+| `vX.Y.0` (minor) | Meaningful content update, new sections, revised conclusions. | v1.0.0 → v1.1.0: added new business line, updated revenue projections. |
+| `vX.Y.Z` (patch) | Editorial fixes, formatting, typos, non-conceptual changes. | v1.1.0 → v1.1.1: fixed table formatting, corrected a date. |
+
+### Versioning Guidelines
+
+- A new object starts at `v1.0.0` (or `v0.1.0` if explicitly draft/experimental).
+- Increment the major version when the core thesis or framework changes.
+- Increment the minor version when substantive content is added or revised.
+- Increment the patch version for editorial or cosmetic changes only.
+- Version numbers apply to the content, not the file. Renaming or moving a file does not require a version bump.
+- Ledger-anchored versions are immutable once anchored (see §Ledger Anchoring). A version bump produces a new anchor, not a modification of the prior one.
+
+---
+
+## Status Tracking
+
+KOI objects carry a **Status** field (tracked in Notion, not encoded in the filename):
+
+| Status | Meaning |
+|--------|---------|
+| `draft` | Work in progress, not yet reviewed. |
+| `in review` | Under active review by stakeholders. |
+| `ready to publish` | Reviewed and approved, awaiting publication. |
+| `published` | Final, externally shareable. |
+
+---
+
+## Access Levels
+
+| Level | Meaning |
+|-------|---------|
+| **Public** | Can be shared externally without restriction. |
+| **Knowledge Commons** | Shared within Regen Commons participants and aligned partners. |
+| **Internal** | RND internal only. |
+
+Projects may define finer-grained sub-tiers within `Internal` (e.g., team-visible, exec-only, finance-owner-only) as project-local access policies. These do not change the canonical three-tier scheme documented here.
+
+---
+
+## AI Readiness
+
+Objects marked **Ready for AI** in the KOI Repo are cleared for ingestion by Regen AI agents (registry review, CTO-in-a-box, knowledge agents). This flag indicates the content is sufficiently structured, accurate, and current to serve as context for AI-assisted workflows.
+
+---
+
+## Ledger Anchoring
+
+Any KOI object whose content represents a **commitment-threshold artifact** — a decision, a plan, a public-facing claim, an externally-verifiable deliverable — can be elevated to a content-addressable Regen Ledger Resource Identifier (RID) via an on-chain anchor.
+
+### When to Anchor
+
+Anchor a KOI object when at least one of the following applies:
+
+- The object records an organizational commitment that should be immutably auditable (decisions, published plans, governance outcomes)
+- The object will be cited by downstream agents or contracts that need content-addressable resolution
+- The object is an externally-verifiable claim (anchored insights, attested analyses, published research)
+- The object is a schema or specification that downstream tooling must pin against
+
+### How to Anchor
+
+Anchoring produces a **triad** of on-chain and off-chain artifacts:
+
+| Artifact | Location | Purpose |
+|---|---|---|
+| `*.canonical.json` | local + anchored hash | the exact content that was hashed |
+| `*.manifest.json` | local + anchored hash | metadata about the canonical content (author, date, workspace path, KOI Name) |
+| `*.receipt.md` | local | the receipt of the anchoring transaction (tx hash, ledger height, block time) |
+
+The anchoring is performed via the Regen Ledger `x/data` module's `MsgAnchor` transaction. The `regen-signing` skill (in `regen-ai-core`) orchestrates the canonical → manifest → signing → receipt flow.
+
+### Post-Anchor Rules
+
+Once an object is anchored at a specific version:
+
+- **The anchored canonical.json is immutable at that hash.** It is never modified in place.
+- **Renaming the file modifies its content hash** if the path is part of the canonical serialization, invalidating the on-chain anchor. Anchored files are therefore rename-hostile — see §Rename Discipline below.
+- **Version bumps produce new anchors.** A `v0.1.0` → `v0.2.0` upgrade requires a new canonical/manifest/receipt triad and a new `MsgAnchor` transaction.
+- **Historical anchors are preserved.** Do not delete or overwrite the canonical/manifest/receipt files for prior versions; they are the authoritative record of what was committed.
+
+### Rename Discipline
+
+Before any bulk text operation (folder rename, mass find-and-replace, automated migration) that might touch anchored files:
+
+1. **Inventory** — identify all anchored canonical/manifest/receipt files in scope
+2. **Classify** each candidate file as:
+   - `anchored-historical` — SKIP (record preserves the original path forever)
+   - `forward-reference only` — UPDATE (text operation is safe)
+   - `anchored-living` — RE-ANCHOR (version bump + changelog + new anchor triad)
+3. **Operate** on the non-anchored set only
+4. **Verify** — re-grep to confirm anchored files' references are unchanged
+
+Failure mode warning: a rename that invalidates an anchor produces no error. The file still exists, still parses, still renders — the on-chain anchor simply no longer resolves. Detection is downstream (verification query fails) and often much later.
+
+### Legacy Names
+
+Some objects anchored prior to v1.2.0 ratification use a **non-canonical first field** (e.g., `strategy.plan.claims-engine-dogfood-plan.v0.1.0` where `strategy` is neither a canonical relevance nor type). These legacy names are preserved as historical record — the ledger anchor is the authoritative identity of the object, and the on-chain record cannot be retroactively corrected without invalidating the anchor.
+
+Going forward (v1.2.0+), all new anchored objects must use canonical `[relevance].[type].[subject].vX.Y.Z`. Legacy objects are grandfathered and should be cross-indexed to canonical names in the artifact registry (if applicable) but never renamed on-chain.
+
+---
+
+## Governance Process
+
+Changes to this naming convention follow the process outlined in [CONTRIBUTING.md](./CONTRIBUTING.md):
+
+1. **Propose** a new type, relevance level, or naming change via GitHub Issue or PR.
+2. **Pilot** the proposed change in practice (minimum 2 weeks, minimum 3 objects using the new convention).
+3. **Review** pilot results with maintainer and at least one other contributor.
+4. **Ratify** via pull request merged to main.
+
+---
+
+## Changelog
+
+See [changelog.md](./changelog.md) for the full record of changes.

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 **Repository Status:** Active Development
 **Lead Maintainer:** Gregory Landua
-**Last Updated:** February 12, 2026
+**Last Updated:** 2026-04-21 (v1.2.0)
 
 ---
 
@@ -19,9 +19,11 @@ KOI is our collective infrastructure for creating coherent, transparent, and act
 
 | Document | Purpose |
 |----------|---------|
-| [`KOI.regen-naming-convention-manifesto.v1.1.0.md`](./KOI.regen-naming-convention-manifesto.v1.1.0.md) | Defines the KOI semantic naming schema, versioning practices, object types, and governance process. |
+| [`KOI.regen-naming-convention-manifesto.v1.2.0.md`](./KOI.regen-naming-convention-manifesto.v1.2.0.md) | **Current manifesto.** Defines the KOI semantic naming schema, versioning practices, object types, ledger anchoring discipline, and governance process. |
+| [`examples/`](./examples/) | Worked examples of each object type (v1.2.0 pilot set + more). |
 | [`CONTRIBUTING.md`](./CONTRIBUTING.md) | Explains how to propose, pilot, and ratify changes to the KOI naming schema. |
 | [`changelog.md`](./changelog.md) | Tracks all approved changes and updates to the naming conventions. |
+| [`KOI.regen-naming-convention-manifesto.v1.1.0.md`](./KOI.regen-naming-convention-manifesto.v1.1.0.md) | Previous version (archived). |
 
 ---
 
@@ -31,10 +33,19 @@ KOI is our collective infrastructure for creating coherent, transparent, and act
 koi-gov/
 │
 ├── README.md                                              # You are here
-├── KOI.regen-naming-convention-manifesto.v1.1.0.md        # Current manifesto
-├── KOI.regen-naming-convention-manifesto.v1.0.0.md        # Previous version (archived)
+├── KOI.regen-naming-convention-manifesto.v1.2.0.md        # Current manifesto
+├── KOI.regen-naming-convention-manifesto.v1.1.0.md        # Previous version (archived)
+├── KOI.regen-naming-convention-manifesto.v1.0.0.md        # Initial version (archived)
 ├── CONTRIBUTING.md                                        # Contribution guidelines
 ├── changelog.md                                           # Record of changes
+├── examples/                                              # Worked examples of each type
+│   ├── README.md
+│   ├── core.spec.regen-os-learning-subroutines.v0.1.0.example.md
+│   ├── core.plan.regen-os-phase-delivery.v0.1.0.example.md
+│   ├── core.overview.regen-os-current-state.v0.1.0.example.md
+│   └── core.registry.regen-os-artifact-registry.v0.1.0.example.md
+├── docs/
+│   └── semantic-naming-properties.md                      # Tool-by-tool implementation
 └── LICENSE                                                # MIT License
 ```
 
@@ -83,6 +94,10 @@ See [CONTRIBUTING.md](./CONTRIBUTING.md) for detailed instructions.
 | `press` | External-facing communications and media materials. |
 | `prompt` | AI prompt templates, agent configurations, or instruction sets. |
 | `transcript` | Meeting or conversation transcripts, typically AI-generated. |
+| `spec` *(v1.2.0)* | Technical specification, agentic loop spec, or agent instruction template. |
+| `plan` *(v1.2.0)* | Phased execution plan with milestones, gates, and resource requirements. |
+| `overview` *(v1.2.0)* | Canonical explainer of a system or domain at a point in time. |
+| `registry` *(v1.2.0)* | Meta-document that indexes or directories other knowledge objects. |
 
 ### Semantic Versioning
 

--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,44 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
 
 ---
 
+## [1.2.0] - 2026-04-21
+
+### Added
+
+- 4 new object types codified from concrete use-cases that had no clean home in v1.1.0:
+  - **spec** — technical specification, agentic loop spec, pattern spec, or agent instruction template
+  - **plan** — phased execution plan with milestones, gates, and resource requirements (distinct from forward-looking `strategy`)
+  - **overview** — canonical explainer of a system or domain at a point in time (distinct from entry-point `readme` and forward-looking `strategy`)
+  - **registry** — meta-document that indexes or directories other knowledge objects (distinct from reference `docs`)
+- **§Ledger Anchoring** section in manifesto — when to anchor, how to anchor (canonical/manifest/receipt triad via `MsgAnchor`), post-anchor rules, rename discipline (classification procedure for bulk operations), and §Legacy Names guidance for pre-v1.2.0 non-canonical anchors
+- **examples/ directory** — worked examples demonstrating each v1.2.0 type, satisfying CONTRIBUTING.md minimum-3-object pilot requirement
+- **"Choosing Between Types" guidance** extended with v1.2.0 pairs: `docs vs spec`, `docs vs registry`, `strategy vs plan`, `readme vs overview`
+- Note in Access Levels section clarifying that projects may define finer-grained sub-tiers (team-visible, exec-only, finance-owner-only) as project-local access policies without changing the canonical three-tier scheme
+
+### Fixed
+
+- `docs/semantic-naming-properties.md` example had multiple issues: undefined type `objective`, double-version suffix `v2025-Q2.v0.1.4`, undefined status `active`. Replaced with canonical `core.strategy.regen-os-overview.v0.1.0` example across all three occurrences (Notion property table, Google Docs metadata block, GitHub YAML frontmatter)
+- `CONTRIBUTING.md` "Who Can Contribute?" heading was missing the `##` prefix, breaking the section's Markdown rendering. Heading restored.
+
+### Pilot Evidence (CONTRIBUTING.md minimum-3-object requirement)
+
+Four RegenOS Phase 0 artifacts (2026-04-21 builders-standup prep session) serve as the pilot set — one per new type:
+
+- `core.spec.regen-os-learning-subroutines.v0.1.0` — atomic closed-loop pattern specification
+- `core.plan.regen-os-phase-delivery.v0.1.0` — 5-phase execution plan from scaffolding through singular OKRs
+- `core.overview.regen-os-current-state.v0.1.0` — point-in-time explainer of RegenOS
+- `core.registry.regen-os-artifact-registry.v0.1.0` — 45-artifact IRI/URL/RID index
+
+Additional evidence for §Ledger Anchoring section: 4 mainnet anchors on `regen-1` (2026-04-17/18) produced via `regen-signing` skill; pre-v1.2.0 legacy anchor `strategy.plan.claims-engine-dogfood-plan.v0.1.0` cited as the §Legacy Names case study.
+
+### Notes
+
+- Manifesto version bumped from v1.1.0 to v1.2.0. `KOI.regen-naming-convention-manifesto.v1.1.0.md` preserved as historical record.
+- No breaking changes. All existing v1.0.0 and v1.1.0 names remain valid.
+- §Legacy Names explicitly grandfathers on-chain anchors predating v1.2.0 that use non-canonical first fields — these cannot be "fixed" retroactively without invalidating the anchor.
+
+---
+
 ## [1.1.0] - 2026-02-12
 
 ### Added

--- a/docs/semantic-naming-properties.md
+++ b/docs/semantic-naming-properties.md
@@ -20,12 +20,15 @@ Use a Notion Database to represent KOI Objects with structured properties:
 
 | Property    | Value                                                  |
 |-------------|--------------------------------------------------------|
-| Title       | Q2 Sprint Strategy – Regen Commons                     |
-| KOI Name    | core.objective.rnd-foundation-sprint.v2025-Q2.v0.1.4  |
-| Type        | core.objective                                         |
+| Title       | RegenOS Overview — Unified Operating System for RND PBC |
+| KOI Name    | core.strategy.regen-os-overview.v0.1.0                 |
 | Relevance   | core                                                   |
-| Version     | v2025-Q2.v0.1.4                                        |
-| Status      | active                                                 |
+| Type        | strategy                                               |
+| Subject     | regen-os-overview                                      |
+| Version     | v0.1.0                                                 |
+| Status      | draft                                                  |
+| Access      | Internal                                               |
+| Ready for AI| yes                                                    |
 
 - **Search Tips**: Notion prioritizes title search. Use filters to query metadata.
 - **Linking**: Canonical versions can link to Google Docs, GitHub, or exported JSON.
@@ -38,12 +41,14 @@ Use a Notion Database to represent KOI Objects with structured properties:
 
 Example metadata block:
 ```
-Title: Q2 Sprint Strategy – Regen Commons
-KOI Name: core.objective.rnd-foundation-sprint.v2025-Q2.v0.1.4
-Version: v2025-Q2.v0.1.4
-Type: core.objective
+Title: RegenOS Overview — Unified Operating System for RND PBC
+KOI Name: core.strategy.regen-os-overview.v0.1.0
 Relevance: core
-Status: active
+Type: strategy
+Subject: regen-os-overview
+Version: v0.1.0
+Status: draft
+Access: Internal
 ```
 
 ---
@@ -55,11 +60,14 @@ Status: active
 
 ```yaml
 ---
-koi_name: core.objective.rnd-foundation-sprint.v2025-Q2.v0.1.4
-version: v2025-Q2.v0.1.4
-type: core.objective
+koi_name: core.strategy.regen-os-overview.v0.1.0
 relevance: core
-status: active
+type: strategy
+subject: regen-os-overview
+version: v0.1.0
+status: draft
+access: Internal
+ready_for_ai: true
 ---
 ```
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,27 @@
+# KOI Examples
+
+This directory contains **worked examples** of KOI objects following the canonical naming convention. Each example is a realistic minimal artifact demonstrating one of the object types defined in the manifesto.
+
+## v1.2.0 Pilot Set (RegenOS)
+
+The four examples below satisfy the CONTRIBUTING.md minimum-3-object pilot requirement for v1.2.0's new object types. Each is grounded in a concrete RegenOS Phase 0 artifact (2026-04-21 builders-standup prep session).
+
+| File | Type | Pilot for |
+|---|---|---|
+| [`core.spec.regen-os-learning-subroutines.v0.1.0.example.md`](./core.spec.regen-os-learning-subroutines.v0.1.0.example.md) | `spec` | Agent-loop and pattern specifications |
+| [`core.plan.regen-os-phase-delivery.v0.1.0.example.md`](./core.plan.regen-os-phase-delivery.v0.1.0.example.md) | `plan` | Phased execution plans |
+| [`core.overview.regen-os-current-state.v0.1.0.example.md`](./core.overview.regen-os-current-state.v0.1.0.example.md) | `overview` | Canonical system explainers |
+| [`core.registry.regen-os-artifact-registry.v0.1.0.example.md`](./core.registry.regen-os-artifact-registry.v0.1.0.example.md) | `registry` | Artifact / URL / RID directories |
+
+## How to Read These Examples
+
+Each example file:
+
+- Uses the canonical KOI Name as its filename: `[relevance].[type].[subject].vX.Y.Z.example.md`
+- Includes YAML frontmatter with the full property set (KOI Name, Type, Relevance, Version, Status, Access, Ready for AI)
+- Has a body that exemplifies the type's structural conventions (e.g., specs have inputs/outputs/loop; registries have tabular indexes)
+- Ends with a note about pilot evidence and revision trigger
+
+## Adding New Examples
+
+When proposing a new object type, version bump, or convention change, include at least 3 pilot examples in this directory following the naming convention above. See [CONTRIBUTING.md](../CONTRIBUTING.md) for the full proposal → pilot → review → ratify process.

--- a/examples/core.overview.regen-os-current-state.v0.1.0.example.md
+++ b/examples/core.overview.regen-os-current-state.v0.1.0.example.md
@@ -1,0 +1,61 @@
+---
+koi_name: core.overview.regen-os-current-state.v0.1.0
+relevance: core
+type: overview
+subject: regen-os-current-state
+version: v0.1.0
+status: draft
+access: Internal
+ready_for_ai: true
+created: 2026-04-21
+steward: Gregory Landua
+---
+
+# RegenOS Current State — Overview (2026-04-21 snapshot)
+
+## Summary
+
+Canonical explainer of RegenOS as of 2026-04-21 builders-standup prep. RegenOS is the **pointer + learning-protocol layer** that unifies RND PBC's already-in-place infrastructure (agentic harness, BizDev, product engineering, ops/finance, knowledge commons) into a coherent but heterogeneously-permissioned fabric we dogfood on ourselves.
+
+## Why `overview` (not `readme` or `strategy`)
+
+- Not a `readme` — this file is not the entry-point navigation for a specific directory or repo; it's an explainer of a system's current state
+- Not a `strategy` — this is a point-in-time snapshot of what exists and how it coheres, not a forward-looking plan (that lives in `core.plan.regen-os-phase-delivery.v0.1.0`)
+- Not a `memo` — memos originate a position; overviews describe a state
+
+## What RegenOS Is
+
+- **Unified**: integrates agentic harness (`ai-ops-finance-harness` + `regen-ai-core`), BizDev pipeline, product engineering, ops/finance, knowledge commons
+- **Lean**: not waterfall — every artifact names revision trigger + kill criterion
+- **Continuously-learning**: through learning subroutines (signal → codification → `.md` → agent → suggestion)
+- **Heterogeneously permissioned**: team-visible default; exec / finance-owner / HR-personal tiers
+- **Content-addressable**: every reference resolves via IRI / URL / RID; high-commitment artifacts anchored to Regen Ledger
+- **Dogfooded**: we run what we sell — 4 mainnet anchors on `regen-1`, Monday digest agent-produced, 33 skills live
+
+## Architecture (at a glance)
+
+Five integration axes × seven lenses × three working primitives:
+
+- **Axes** — agentic harness · BizDev pipeline · product engineering · ops/finance/HR · strategy & objective-function clusters
+- **Lenses** — heptad · claims engine · ledger · web app / demo pipeline · OPAL coherence · PACTO · Becca/Dave triad
+- **Primitives** — learning subroutines · sensor pipeline · versioning protocol
+
+## What's Live Today (empirical)
+
+- 🟢 Four-Surface ops harness + `regen-signing` shipped 2026-04-17 + 4 mainnet anchors + 33 skills + KOI MCP + Monday digest
+- 🟡 `gtm-validation-learner` scaffolded-but-dormant (6 diagnosed root causes, structural fix pending)
+- 🔵 `claims-engine-unit-economics` research charter; liability/underwriting discovery pipeline (speculative, 7-month verdict)
+
+## Pilot Evidence
+
+- Source workspace: `workspaces/RegenOS/context/regen-os-overview-v0.1.md`
+- KOI Repo canonical-strategy entry: `core.strategy.regen-os-overview.v0.1.0` (https://www.notion.so/34925b77eda18173b759f906ba2c54a5) — same content, different frame (strategy = forward-looking; overview = current-state snapshot). The two types complement; an overview gets superseded by the next overview, while a strategy evolves version-by-version.
+- Companion v1.2.0 pilots: `core.spec.regen-os-learning-subroutines.v0.1.0` · `core.plan.regen-os-phase-delivery.v0.1.0` · `core.registry.regen-os-artifact-registry.v0.1.0`
+
+## Revision Trigger
+
+Any new integration axis added · any of the 5 currently-live or 3 dormant/speculative systems materially shifts status · quarterly snapshot refresh.
+
+## Kill Criterion
+
+If this overview is not the reliable "what is RegenOS" landing page for new team members after Phase 2 (end of April), the `overview` type isn't earning its keep — fold back into `readme` or `strategy`.

--- a/examples/core.plan.regen-os-phase-delivery.v0.1.0.example.md
+++ b/examples/core.plan.regen-os-phase-delivery.v0.1.0.example.md
@@ -1,0 +1,54 @@
+---
+koi_name: core.plan.regen-os-phase-delivery.v0.1.0
+relevance: core
+type: plan
+subject: regen-os-phase-delivery
+version: v0.1.0
+status: draft
+access: Internal
+ready_for_ai: true
+created: 2026-04-21
+steward: Gregory Landua
+---
+
+# RegenOS Phased Delivery Plan v0.1
+
+## Summary
+
+Phased execution plan for RegenOS — the unified, lean, continuously-learning operating system for RND PBC. Five phases from scaffolding (today) through steady-state OKRs (June 2026), each with explicit gates and kill criteria.
+
+## Why `plan` (not `strategy`)
+
+This artifact is the **execution sequence** (when + who + gates), not the forward-looking framework (why + what). The strategy lives in `core.strategy.regen-os-overview.v0.1.0`; this plan operationalizes it.
+
+## Phases
+
+| Phase | When | Delivery | Gate to next |
+|---|---|---|---|
+| 0 | 2026-04-21 (today) | CLAUDE.md + 6 context artifacts (overview · registry · swim lane · subroutines · schema catalog · deck) | ICs confirm swim-lane stewardship |
+| 1 | this week (ICs) | GitHub repo scoped (team-visible default); Notion dashboard spec; stewards confirmed | Repo approved + dashboard spec signed off |
+| 2 | end of April (all-hands) | `regen-network/regen-os` repo live; Notion dashboard skeleton; first closed subroutine loop; first RegenOS ledger anchor | First subroutine loop closes end-to-end |
+| 3 | May | Unified Notion dashboard live with heterogeneous permission views; sensor pipeline proven for 1 strategic-upgrade class | Sensor pipeline produces 1 actionable upgrade memo |
+| 4 | June | Singular RND-wide OKRs derived via PACTO; steady-state OS; quarterly refresh cadence | — (steady state) |
+
+## Resource Requirements
+
+- Gregory (steward, orchestrator) — active all phases
+- ICs (role-specific stewards) — Phase 1 onward
+- Dave (COO, BizDev) — Phase 1 onward for stewardship validation
+- Marie + Darren (product engineering) — Phase 1 onward
+- Christian (CFO ops) · Mark (finance) — Phase 2+ for exec/finance-owner tier integration
+
+## Kill Criterion
+
+If after Phase 1 no ICs have volunteered swim-lane stewardship, RegenOS framing is not resonating — pause before Phase 2 and restructure the deck/narrative.
+
+## Revision Trigger
+
+Post-standup feedback · any phase gate missed by more than one week · addition of a sixth integration axis.
+
+## Pilot Evidence
+
+- Source workspace: `workspaces/RegenOS/context/regen-os-overview-v0.1.md` §Phased Delivery
+- Builders-standup deck Slide 5 (Candidate Product Roadmap) includes this plan's Track A
+- Companion v1.2.0 pilots: `core.spec.regen-os-learning-subroutines.v0.1.0` · `core.overview.regen-os-current-state.v0.1.0` · `core.registry.regen-os-artifact-registry.v0.1.0`

--- a/examples/core.registry.regen-os-artifact-registry.v0.1.0.example.md
+++ b/examples/core.registry.regen-os-artifact-registry.v0.1.0.example.md
@@ -1,0 +1,70 @@
+---
+koi_name: core.registry.regen-os-artifact-registry.v0.1.0
+relevance: core
+type: registry
+subject: regen-os-artifact-registry
+version: v0.1.0
+status: draft
+access: Internal
+ready_for_ai: true
+created: 2026-04-21
+steward: Gregory Landua
+---
+
+# RegenOS Knowledge Artifact Registry v0.1 — IRI/URL/RID Map
+
+## Summary
+
+Index of 45 knowledge artifacts across 9 sections, each with canonical URL, access tier, steward, and update cadence. Every RegenOS artifact must cite from or add to this registry — workspace-path-only references are never sufficient for non-personal audiences (Reference Accessibility Gate).
+
+## Why `registry` (not `docs`)
+
+- The primary content of this artifact **is the index itself** — not the content of what's indexed
+- Downstream agents and humans use it as a lookup table, not as reference documentation
+- Updates follow an "add a row" cadence, not a "revise the prose" cadence
+- `docs` describe a thing; `registry` indexes many things
+
+## Structure
+
+Each row carries six fields:
+
+| Field | Purpose |
+|---|---|
+| Artifact | Short identifier |
+| Canonical URL | Resolvable surface for the artifact |
+| RID | Regen Ledger resource identifier (if anchored) |
+| Access tier | team / exec / finance / personal / client |
+| Steward | Named human responsible for keeping it current |
+| Cadence | How often updates are expected |
+
+## Sections
+
+The registry is organized into 9 sections:
+
+1. Agentic harness repos (`ai-ops-finance-harness`, `regen-ai-core`, contexts/, skills/)
+2. Business development (BizDev pipeline, GTM thesis, Becca/Dave triad docs)
+3. Product engineering (process page, spec gate, demo-to-spec)
+4. Ops / Finance / HR (restricted-access, exec and finance-owner tiers)
+5. Strategy & objective-function clusters
+6. Frameworks & lenses (heptad, PACTO, OPAL, Coherence Protocol)
+7. Knowledge commons & ledger substrate (KOI Notion Repo, KOI MCP, Heartbeat, `regen-1`, regen-signing, 4 mainnet anchors)
+8. Personal & session layers (vault/, inbox/, session journals, auto-memory)
+9. RegenOS self-references (CLAUDE.md, overview, swim lane, subroutines, schema library, deck)
+
+## RID Status
+
+All 45 entries currently carry `[NO RID YET]` in the RID column. Phase 1 pilot (this week) selects 3–5 high-use artifacts to elevate to RID-bearing status via the `regen-signing` skill — first RegenOS ledger anchor target for Phase 2 (end-of-April).
+
+## Pilot Evidence
+
+- Source workspace: `workspaces/RegenOS/context/knowledge-artifact-registry-v0.1.md`
+- KOI Repo entry: https://www.notion.so/34925b77eda1812ca4efc382858bf1a7
+- Companion v1.2.0 pilots: `core.spec.regen-os-learning-subroutines.v0.1.0` · `core.plan.regen-os-phase-delivery.v0.1.0` · `core.overview.regen-os-current-state.v0.1.0`
+
+## Revision Trigger
+
+Any new integration surface added to RegenOS · any artifact promoted to RID-bearing · quarterly steward review.
+
+## Kill Criterion
+
+If by end of Phase 1 (this week) fewer than 5 artifacts have RIDs, content-addressing discipline is decorative rather than operational — escalate at Phase 2 all-hands and either re-scope or retire the discipline.

--- a/examples/core.spec.regen-os-learning-subroutines.v0.1.0.example.md
+++ b/examples/core.spec.regen-os-learning-subroutines.v0.1.0.example.md
@@ -1,0 +1,75 @@
+---
+koi_name: core.spec.regen-os-learning-subroutines.v0.1.0
+relevance: core
+type: spec
+subject: regen-os-learning-subroutines
+version: v0.1.0
+status: draft
+access: Internal
+ready_for_ai: true
+created: 2026-04-21
+steward: Gregory Landua
+---
+
+# RegenOS Learning Subroutines v0.1 — Atomic Closed-Loop Pattern
+
+## Summary
+
+The atomic primitive of RegenOS. A learning subroutine is a closed loop: **signal → capture → PACTO codification → `.md` persistence → agent consumption → strategic suggestion → new signal**. This is what turns a static `.md` file into living infrastructure.
+
+## Why `spec` (not `docs`)
+
+This artifact is a **precise definition of a technical pattern intended to be implemented or executed against** — not a general reference document. Three distinct subroutines are specified with identical structure (signal / capture / codification / persist / consumption / suggestion); downstream agents and humans are expected to instantiate new subroutines against this template. That is spec-nature, not docs-nature.
+
+## Loop Definition
+
+```
+  ambient signal  ─▶  capture  ─▶  PACTO codification
+  (meetings,           (Otter,      (Constitutive →
+   commits,             vault,       Normative →
+   edits,               inbox)       Legal stages)
+   events)                             │
+                                       ▼
+  strategic                    canonical .md
+  suggestion ◀── agent re-reads ◀── (KOI-anchored
+  (weekly,      (skill, cron,         when commitment
+   monthly,      agent)               threshold crossed)
+   quarterly)
+      │
+      └─ back to ambient signal ─────────────────────────
+```
+
+**Inputs:** ambient signal + codification protocol.
+**Outputs:** updated `.md` + agent-produced suggestions.
+**Cadence:** per-loop varies (weekly for GTM, continuous for ops-harness, per-demo for engineering-product).
+
+## Three Exemplar Instances
+
+1. **GTM thesis loop** — Otter customer-discovery call → PACTO codification → `gtm-thesis.md` update → `gtm-validation-learner` re-reads → weekly GTM digest
+2. **ai-ops-harness weekly retro** — Monday digest + session journals → retro-named issues → harness `.md` commit → next session inherits improvement
+3. **Engineering-product Spec Gate** — Demo feedback → Spec Gate review → product-brief `.md` update → coding agent reads → shipped feature
+
+Full details in `workspaces/RegenOS/context/learning-subroutines-v0.1.md`.
+
+## Design Lessons (carried from gtm-validation-learner dormancy diagnosis)
+
+1. Per-call file split kills merge conflicts
+2. Rotating ownership prevents single-committer bottleneck
+3. Merged PRs unblock downstream work
+4. Read-only install disclaimers scare away contributors
+5. CONTRIBUTING guide from day 1
+6. Stale thesis is worse than no thesis — schedule forced revisitation
+
+## Pilot Evidence
+
+- Source workspace: `workspaces/RegenOS/context/learning-subroutines-v0.1.md`
+- KOI Repo entry: https://www.notion.so/34925b77eda181629b12f471198fa76c
+- Companion v1.2.0 pilots: `core.plan.regen-os-phase-delivery.v0.1.0` · `core.overview.regen-os-current-state.v0.1.0` · `core.registry.regen-os-artifact-registry.v0.1.0`
+
+## Revision Trigger
+
+After first end-to-end loop runs · after a new candidate subroutine is stewarded · after a dormancy pattern is diagnosed in a live subroutine.
+
+## Kill Criterion
+
+If by end of Phase 2 (end-of-April 2026) none of the three exemplar subroutines has closed one end-to-end loop, the subroutine pattern is not yet the right primitive — revisit as a batch-processing model instead of per-loop.


### PR DESCRIPTION
## Summary

Proposes **KOI Naming Convention Manifesto v1.2.0** — a minor-version update (no breaking changes) addressing four concrete gaps observed while operationalizing RegenOS.

- 4 new object types — `spec`, `plan`, `overview`, `registry` — codified from real use-cases that had no clean home in v1.1.0
- New **§Ledger Anchoring** section — when/how to elevate KOI objects to content-addressable Regen Ledger RIDs, with rename discipline and §Legacy Names grandfathering
- New **`examples/`** directory — one worked example per new type, serving as the CONTRIBUTING.md minimum-3-object pilot set
- Two small bugfixes — `docs/semantic-naming-properties.md` broken example, `CONTRIBUTING.md` missing heading prefix

## Why Each Change

Each addition is grounded in a specific concrete artifact from today's RegenOS Phase 0 session (2026-04-21 builders-standup prep). No hallucinated practice — every claim traces to a file that now exists.

### `spec` type
Today I needed to name an agentic loop specification defining three closed-loop patterns (GTM thesis loop, ai-ops-harness retro loop, engineering-product Spec Gate loop). No v1.1.0 type fit — `docs` is too general (this is implementation-ready, not reference material); `strategy` is forward-looking framework (this is a spec to execute against). `spec` fills the gap.

### `plan` type
The 2026-04-17 mainnet-anchored artifact `strategy.plan.claims-engine-dogfood-plan.v0.1.0` already uses `plan` as its type in practice, but `plan` wasn't in v1.1.0's type list (and incidentally that anchor uses a non-canonical first field — see §Legacy Names). Codifying `plan` aligns the manifesto with existing anchored practice. A `plan` differs from `strategy`: strategy is the framework (why + what); plan is the execution sequence (when + who + gates).

### `overview` type
Top-level explainers of a system or domain at a point in time. Not a `readme` (those are entry-point navigation for a directory); not a `strategy` (those are forward-looking); not a `memo` (those originate a position). Grounded in today's `regen-os-overview-v0.1.md` artifact.

### `registry` type
Meta-documents whose primary content **is the index itself** — not the content of what's indexed. Grounded in today's 45-artifact IRI/URL/RID registry. Downstream agents use it as a lookup table. Updates follow an add-a-row cadence, not a revise-the-prose cadence. Distinct from reference `docs`.

### §Ledger Anchoring section
`regen-signing` shipped 2026-04-17, produced 4 mainnet anchors on `regen-1` (Apr 17/18). Anchoring a KOI object produces a canonical/manifest/receipt triad via `MsgAnchor`. v1.1.0 was silent on this entire discipline. The new section also documents **rename discipline** — anchored files are rename-hostile because modifying the file modifies its content hash, silently invalidating the on-chain anchor. A manifesto-level classification procedure (anchored-historical vs. forward-reference vs. anchored-living) prevents this failure mode.

### §Legacy Names
On-chain anchors predating v1.2.0 ratification use first fields that aren't canonical relevance values (e.g., `strategy.plan.claims-engine-dogfood-plan.v0.1.0` where `strategy` is a type, not a relevance). These cannot be retroactively corrected without invalidating the anchor. The section formalizes grandfathering — legacy names preserved as historical record; all new anchored objects use canonical `[relevance].[type].[subject].vX.Y.Z` going forward.

## Pilot Evidence

CONTRIBUTING.md requires a minimum of 3 objects using the proposed convention, piloted for at least 2 weeks. This PR includes **4 RegenOS Phase 0 artifacts** as the pilot set — one per new type — all produced today (2026-04-21) as part of the RegenOS unified-operating-system scaffolding session:

| KOI Name | Type | Pilot In |
|---|---|---|
| `core.spec.regen-os-learning-subroutines.v0.1.0` | `spec` | KOI Repo + `examples/` |
| `core.plan.regen-os-phase-delivery.v0.1.0` | `plan` | `examples/` |
| `core.overview.regen-os-current-state.v0.1.0` | `overview` | `examples/` |
| `core.registry.regen-os-artifact-registry.v0.1.0` | `registry` | KOI Repo + `examples/` |

Plus an additional canonical entry already in the KOI Repo: `core.strategy.regen-os-overview.v0.1.0` (valid under v1.1.0; companion to the four v1.2.0 pilots).

**Pilot duration note:** this is day zero of piloting. Proposing the PR for review now, with the governance call as the ratification forum. Pilot can continue during the review window to satisfy the 2-week minimum before ratification.

## Bugfixes

**`docs/semantic-naming-properties.md`** — the worked example `core.objective.rnd-foundation-sprint.v2025-Q2.v0.1.4` (appearing in three places: Notion property table, Google Docs metadata block, GitHub YAML frontmatter) had three issues:
1. `objective` is not a defined type in any version of the manifesto
2. `v2025-Q2.v0.1.4` is a double-version — the versioning scheme is single-semver
3. `Status: active` is not in the canonical status list (`draft`/`in review`/`ready to publish`/`published`)

Replaced all three occurrences with a canonical v1.2.0 example: `core.strategy.regen-os-overview.v0.1.0`.

**`CONTRIBUTING.md`** — the "Who Can Contribute?" section header was missing its `##` prefix (line 6), breaking Markdown rendering. Restored.

## Scope Check

Version bump is **minor** (v1.1.0 → v1.2.0):
- No breaking changes
- All existing v1.0.0 and v1.1.0 names remain valid
- New types are additions, not replacements
- §Ledger Anchoring and §Legacy Names formalize practices that were already implicitly in use
- Bugfixes are corrective, not interpretive

## Test Plan

- [x] Manifesto v1.2.0 reads cleanly end-to-end; examples in §Naming Structure reference real pilots
- [x] All 4 examples/ files exist, have valid frontmatter, and demonstrate their type's structural conventions
- [x] examples/README.md links to each pilot
- [x] README.md repository structure diagram reflects the new files
- [x] changelog.md v1.2.0 entry follows Keep-a-Changelog format
- [x] docs/semantic-naming-properties.md has no remaining broken examples (verify by searching `core.objective`, `v2025-Q2`, `Status: active`)
- [x] CONTRIBUTING.md "Who Can Contribute?" heading renders as a section header
- [ ] **Governance call review** — surface in weekly KOI governance call for ratification feedback
- [ ] **Pilot extension** — at least one more use of each new type by a second contributor before ratification (per CONTRIBUTING.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)