### PR TITLE
KOI publishing-spine metadata (manifesto v1.3.0): five-tier Access, RID, Publication, canonical Vertical

### DIFF
--- a/KOI.regen-naming-convention-manifesto.v1.3.0.md
+++ b/KOI.regen-naming-convention-manifesto.v1.3.0.md
@@ -1,0 +1,335 @@
+# KOI Regen Naming Convention Manifesto
+
+**Version:** 1.3.0
+**Status:** Proposed — pending governance-call ratification
+**Maintainer:** Gregory Landua
+**Last Updated:** 2026-07-01
+
+> **v1.3.0 note.** This version stacks on the pending v1.2.0 PR (`claude/v1.2.0-types-anchoring-examples`) and adds the **publishing-spine metadata layer**: a five-tier Access scheme aligned with the RegenOS access model, a first-class **RID** identity property, a **Publication** (per-surface publish decision) property, and ratification of the canonical **Vertical** controlled vocabulary. v1.2.0 should be ratified/merged first, or the two ratified together. No existing KOI name is invalidated.
+
+---
+
+## Purpose
+
+This document defines the canonical semantic naming conventions for KOI (Knowledge Organizing Infrastructure) objects within Regen Network. These conventions enable coherent coordination between distributed teams, AI agents, and community participants.
+
+---
+
+## Naming Structure
+
+```
+[relevance].[type].[subject].vX.Y.Z
+```
+
+### Examples
+
+```
+core.strategy.regen-os-overview.v0.1.0
+core.spec.regen-os-learning-subroutines.v0.1.0
+core.plan.regen-os-phase-delivery.v0.1.0
+core.registry.regen-os-artifact-registry.v0.1.0
+core.overview.regen-commons-current-state.v0.1.0
+relevant.analysis.distribution-moat-dual-framework.v1.0.0
+relevant.research.aimma-regulatory-landscape.v1.0.0
+background.notes.ecosystem-partner-landscape.v0.3.1
+```
+
+See [`examples/`](./examples/) for worked examples of each v1.2.0 type.
+
+---
+
+## Relevance Levels
+
+| Level | Meaning | Typical Use |
+|-------|---------|-------------|
+| `core` | Fundamental, actively used, essential to strategic decisions. | Active strategy docs, governance frameworks, canonical references. |
+| `relevant` | Informative, actively cited, influential in ongoing work. | Supporting analyses, partner-specific materials, active research. |
+| `background` | Contextual, supportive, historical, or ambient reference. | Archived decisions, historical context, exploratory notes. |
+
+---
+
+## Object Types
+
+### Original Types (v1.0.0)
+
+| Type | Description | When to Use |
+|------|-------------|-------------|
+| `memo` | Structured strategic or operational document. | Formal communication, position papers, internal proposals. |
+| `analysis` | Data-driven or qualitative deep dive. | Market analysis, deal modeling, technical evaluation. |
+| `notes` | Informal or exploratory ideas and documentation. | Meeting notes, brainstorms, working drafts. |
+| `decision` | Official organizational decision record. | Governance votes, strategic commitments, policy changes. |
+| `readme` | Canonical documentation for directories or patterns. | Repository docs, onboarding guides, system overviews. |
+
+### Expanded Types (v1.1.0)
+
+Codified in v1.1.0 from active Notion KOI Repo usage.
+
+| Type | Description | When to Use |
+|------|-------------|-------------|
+| `strategy` | Forward-looking strategic framework or business model. | GTM plans, business models, roadmaps, investment narratives. |
+| `docs` | Reference documentation, specifications, or guides. | Technical specs, API docs, process documentation, handbooks. |
+| `feedback` | Structured feedback on proposals, products, or processes. | Review responses, partner feedback, user research findings. |
+| `research` | Investigative or exploratory research output. | Market research, regulatory landscape scans, technology assessments. |
+| `press` | External-facing communications and media materials. | Blog posts, press releases, public statements, media briefs. |
+| `prompt` | AI prompt templates, agent configurations, or instruction sets. | System prompts, skill definitions, agent specs, prompt libraries. |
+| `transcript` | Meeting or conversation transcript, typically AI-generated. | Otter.ai transcripts, call recordings, interview records. |
+
+### Expanded Types (v1.2.0)
+
+The following types emerged from active use cases that had no clean home in v1.1.0. Each is grounded in a concrete RegenOS artifact or mainnet-anchored artifact; see [`examples/`](./examples/) for the worked pilots satisfying the CONTRIBUTING.md minimum-3-object pilot requirement.
+
+| Type | Description | When to Use | Pilot |
+|------|-------------|-------------|-------|
+| `spec` | Technical specification, agentic loop spec, pattern specification, or agent instruction template. | Agent loop definitions, pattern specs, schema specs, protocol specifications that aren't general `docs`. | `core.spec.regen-os-learning-subroutines.v0.1.0` |
+| `plan` | Phased execution plan with milestones, gates, and resource requirements. | Dogfood plans, discovery pipelines, phased delivery plans distinct from forward-looking `strategy`. | `core.plan.regen-os-phase-delivery.v0.1.0` |
+| `overview` | Canonical explainer of a system or domain at a point in time. | Top-level explainers that aren't directory entry points (`readme`) and aren't forward-looking (`strategy`). | `core.overview.regen-os-current-state.v0.1.0` |
+| `registry` | Meta-document that indexes or directories other knowledge objects. | Artifact registries, URL/RID maps, schema libraries, catalog indexes distinct from reference `docs`. | `core.registry.regen-os-artifact-registry.v0.1.0` |
+
+### Deprecated Types
+
+| Type | Status | Notes |
+|------|--------|-------|
+| Final Analysis | Deprecated — use `analysis` instead. | Was used in Notion KOI Repo as a status marker. Use `analysis` as the type and track completion status separately via the Status field. |
+
+---
+
+## Choosing Between Types
+
+When the distinction is ambiguous:
+
+- **memo vs strategy** — Memos communicate a position or proposal; strategies lay out a forward-looking plan with phases, milestones, or resource requirements.
+- **analysis vs research** — Analyses evaluate a specific question or decision; research explores a domain or landscape more broadly.
+- **docs vs readme** — Readmes are entry-point documentation for a specific directory or system; docs are standalone reference materials.
+- **docs vs spec** — Docs are general reference material; specs are precise definitions of a technical artifact, agent loop, or pattern intended to be implemented or executed against.
+- **docs vs registry** — Docs describe a thing; registries index many things. A registry's primary content is the index itself, not the content of what's indexed.
+- **strategy vs plan** — Strategy is the framework (why + what); plan is the execution sequence (when + who + gates). A strategy contains a plan; a plan operationalizes a strategy.
+- **readme vs overview** — Readmes are entry-points to a directory/repo (how to navigate this place); overviews are explainers of a system/domain (what this system is and how it works). A readme answers "start here"; an overview answers "what is this?"
+- **notes vs transcript** — Notes are human-authored (even if rough); transcripts are machine-generated or verbatim records.
+- **feedback vs memo** — Feedback responds to something specific; memos originate a position.
+
+---
+
+## Semantic Versioning
+
+KOI objects use semantic versioning to track conceptual evolution:
+
+| Version Component | Meaning | Example |
+|-------------------|---------|---------|
+| `vX.0.0` (major) | Fundamental conceptual shift, reframe, or restructure. | v1.0.0 → v2.0.0: complete rethinking of token utility model. |
+| `vX.Y.0` (minor) | Meaningful content update, new sections, revised conclusions. | v1.0.0 → v1.1.0: added new business line, updated revenue projections. |
+| `vX.Y.Z` (patch) | Editorial fixes, formatting, typos, non-conceptual changes. | v1.1.0 → v1.1.1: fixed table formatting, corrected a date. |
+
+### Versioning Guidelines
+
+- A new object starts at `v1.0.0` (or `v0.1.0` if explicitly draft/experimental).
+- Increment the major version when the core thesis or framework changes.
+- Increment the minor version when substantive content is added or revised.
+- Increment the patch version for editorial or cosmetic changes only.
+- Version numbers apply to the content, not the file. Renaming or moving a file does not require a version bump.
+- Ledger-anchored versions are immutable once anchored (see §Ledger Anchoring). A version bump produces a new anchor, not a modification of the prior one.
+
+---
+
+## Status Tracking
+
+KOI objects carry a **Status** field (tracked in Notion, not encoded in the filename):
+
+| Status | Meaning |
+|--------|---------|
+| `draft` | Work in progress, not yet reviewed. |
+| `in review` | Under active review by stakeholders. |
+| `ready to publish` | Reviewed and approved, awaiting publication. |
+| `published` | Final, externally shareable. |
+
+---
+
+## Access Levels
+
+KOI objects carry an **Access** level that governs *who may see the object*. As of v1.3.0 the canonical scheme is **five tiers**, aligned one-to-one with the RegenOS / Regen Commons access model so that a single access value means the same thing across the vault, the wiki, the KOI Repo, and every downstream publishing surface.
+
+| Level | Meaning | Audience |
+|-------|---------|----------|
+| **Public** | Shareable externally without restriction. | Anyone. |
+| **Knowledge Commons** | Shareable within Regen Commons participants and aligned community contributors. | Community / commons contributors. |
+| **Partner** | Shareable with a **named, invited** partner organization under explicit, per-partner approval. | Invited partner orgs. |
+| **Internal** | RND PBC + core contributors only. | RND internal. |
+| **Personal** | Local / individual only; **never federated or published**. This is the sovereignty floor. | The author. |
+
+### Why five tiers (v1.3.0 change)
+
+Prior to v1.3.0 the manifesto codified three tiers and treated finer distinctions as "project-local policies." In practice the rest of the ecosystem (RegenOS access model, the Reference-Accessibility Gate, the Federation Layer consent envelope, the vault/wiki `access:` frontmatter) uses **five tiers**, and the three-tier scheme could not express the two cases that matter most for cooperative publishing:
+
+- **Partner** — the "close-collaborator" tier. Publishing a knowledge object to a *named* partner (or a partner-scoped surface such as a Catalist/Murmurations trove) is a distinct decision from publishing to the open commons. Without a `Partner` tier, partner-scoped publication has no representable state.
+- **Personal** — the sovereignty floor. Making `Personal` explicit lets automated gates *exclude* it mechanically rather than by reviewer memory.
+
+### Mapping to the workspace access model
+
+| KOI Access | RegenOS / vault `access:` | Federation consent envelope |
+|---|---|---|
+| Public | `public` | `public` |
+| Knowledge Commons | `commons` | `commons` |
+| Partner | `partner` | `partner` |
+| Internal | `internal` | `internal` |
+| Personal | `personal` | `personal` |
+
+### Migration note
+
+`Public`, `Knowledge Commons`, and `Internal` are unchanged — every existing object keeps its Access value. `Partner` and `Personal` are **added**. Objects previously stretched to fit (e.g., a partner-shared doc marked `Knowledge Commons`, or a personal note marked `Internal`) should be re-tagged during the metadata upgrade (see the controlled-vocabulary and rollout guidance). Projects may still define finer sub-tiers *within* `Internal` (team-visible, exec-only, finance-owner-only) as project-local policies; these do not change the canonical five-tier scheme.
+
+### Access is orthogonal to Relevance and to Publication
+
+Three independent axes, each answering a different question:
+
+- **Access** — *who may see this?* (sensitivity)
+- **Relevance** — *how foundational is this?* (`core` / `relevant` / `background`)
+- **Publication** — *has this been approved to emit to a specific external surface?* (see §Publication below)
+
+A `core` object may be `Personal`; a `Public` object may be `background`; an `Internal` object is never published to any external surface regardless of Relevance. Do not collapse these axes.
+
+---
+
+## AI Readiness
+
+Objects marked **Ready for AI** in the KOI Repo are cleared for ingestion by Regen AI agents (registry review, CTO-in-a-box, knowledge agents). This flag indicates the content is sufficiently structured, accurate, and current to serve as context for AI-assisted workflows.
+
+---
+
+## Publication (v1.3.0)
+
+**Access says who *may* see an object. Publication says whether it has been *approved to emit* to a specific external surface, and to which one.** These are different decisions and must not be conflated with `Status` (which tracks internal editorial lifecycle) or with `Access` (which tracks sensitivity).
+
+The **Publication** property is a set of zero or more publication targets. An object with no publication target is not published anywhere, regardless of its `Status` or `Access`.
+
+| Publication target | Meaning | Minimum Access required |
+|---|---|---|
+| *(none)* | Not published to any external surface. Default. | — |
+| **Public Web** | Rendered on a public Regen surface (site, public wiki, public Notion). | Public |
+| **Open Index** | Emitted to the public ecosystem index (Murmurations / Catalist / Arcos public trove). | Public |
+| **Commons Trove** | Emitted to a Regen Commons / community-scoped trove. | Knowledge Commons |
+| **Partner Space** | Emitted to a **named** partner surface under explicit approval. | Partner |
+
+### Rules
+
+- **P1 — Publish-by-decision, not by default.** An object is published only if a human or governance process sets a Publication target. `Status: published` alone does **not** authorize any external emit.
+- **P2 — Access is the ceiling.** A target may be set only if the object's Access permits it (see table). The gate rejects, e.g., an `Internal` object with any Publication target, and a `Public` object may still carry *no* target.
+- **P3 — Per-surface consent.** Approving `Commons Trove` does not approve `Open Index`. Each target is a separate decision, logged with (RID, target, timestamp, approver).
+- **P4 — Personal never publishes.** A `Personal` object can carry no Publication target under any circumstances.
+- **P5 — Governance of the flag.** Who may set a Publication target is a governed decision (steward / council / automated policy). Projects define the setter; the *existence and semantics* of the property are canonical.
+
+The Publication property is the machine-checkable point where the Sensitivity and Reference-Accessibility gates are enforced structurally rather than by reviewer memory. It is the "labeler" in the publication-adapter architecture (KOI → Catalist/Murmurations and other AppViews).
+
+---
+
+## Resource Identifier (RID) (v1.3.0)
+
+The **KOI Name** (`[relevance].[type].[subject].vX.Y.Z`) is a human-legible, mutable-by-versioning label. It is **not** a resolvable identity. v1.3.0 promotes the **RID** to a first-class metadata property: the durable, resolvable identifier that survives publication, federation, and cross-surface reference.
+
+### Format
+
+```
+orn:regen.<entity-class>:<context>/<reference>
+```
+
+Examples:
+
+```
+orn:regen.document:notion/<page-uuid>
+orn:regen.artifact:koi/core.overview.regen-os-current-state.v0.1.0
+orn:regen.entity:org/regen-network
+```
+
+### Rules
+
+- **RID-1 — Every KOI object has an RID.** It is minted on creation and is stable for the life of the object across renames and version bumps.
+- **RID-2 — RID is the identity that travels.** When an object is published to any surface (Publication targets above), the RID is emitted with it as the durable back-reference. This is the DID-equivalent in the AT-Protocol-analogy publication model: presentation surfaces are replaceable; the RID is not.
+- **RID-3 — Round-trip requirement.** Any external reference or read-back MUST resolve through the RID back to the canonical KOI object. A published profile that drops its RID is non-conformant.
+- **RID-4 — RID ≠ KOI Name ≠ ledger anchor.** The RID resolves the *object*; the KOI Name *labels a version* of it; a ledger anchor (below) *proves the content* of a specific version. An object may have all three; the RID is the join key.
+- **RID-5 — Resolution.** The RID resolves via the KOI resolver (see the knowledge-accessibility pipeline). Until the resolver is live, the RID is recorded as a metadata property and resolution is manual; the format is fixed now so no re-minting is needed later.
+
+---
+
+## Ledger Anchoring
+
+Any KOI object whose content represents a **commitment-threshold artifact** — a decision, a plan, a public-facing claim, an externally-verifiable deliverable — can be elevated to a content-addressable Regen Ledger Resource Identifier (RID) via an on-chain anchor.
+
+### When to Anchor
+
+Anchor a KOI object when at least one of the following applies:
+
+- The object records an organizational commitment that should be immutably auditable (decisions, published plans, governance outcomes)
+- The object will be cited by downstream agents or contracts that need content-addressable resolution
+- The object is an externally-verifiable claim (anchored insights, attested analyses, published research)
+- The object is a schema or specification that downstream tooling must pin against
+
+### How to Anchor
+
+Anchoring produces a **triad** of on-chain and off-chain artifacts:
+
+| Artifact | Location | Purpose |
+|---|---|---|
+| `*.canonical.json` | local + anchored hash | the exact content that was hashed |
+| `*.manifest.json` | local + anchored hash | metadata about the canonical content (author, date, workspace path, KOI Name) |
+| `*.receipt.md` | local | the receipt of the anchoring transaction (tx hash, ledger height, block time) |
+
+The anchoring is performed via the Regen Ledger `x/data` module's `MsgAnchor` transaction. The `regen-signing` skill (in `regen-ai-core`) orchestrates the canonical → manifest → signing → receipt flow.
+
+### Post-Anchor Rules
+
+Once an object is anchored at a specific version:
+
+- **The anchored canonical.json is immutable at that hash.** It is never modified in place.
+- **Renaming the file modifies its content hash** if the path is part of the canonical serialization, invalidating the on-chain anchor. Anchored files are therefore rename-hostile — see §Rename Discipline below.
+- **Version bumps produce new anchors.** A `v0.1.0` → `v0.2.0` upgrade requires a new canonical/manifest/receipt triad and a new `MsgAnchor` transaction.
+- **Historical anchors are preserved.** Do not delete or overwrite the canonical/manifest/receipt files for prior versions; they are the authoritative record of what was committed.
+
+### Rename Discipline
+
+Before any bulk text operation (folder rename, mass find-and-replace, automated migration) that might touch anchored files:
+
+1. **Inventory** — identify all anchored canonical/manifest/receipt files in scope
+2. **Classify** each candidate file as:
+   - `anchored-historical` — SKIP (record preserves the original path forever)
+   - `forward-reference only` — UPDATE (text operation is safe)
+   - `anchored-living` — RE-ANCHOR (version bump + changelog + new anchor triad)
+3. **Operate** on the non-anchored set only
+4. **Verify** — re-grep to confirm anchored files' references are unchanged
+
+Failure mode warning: a rename that invalidates an anchor produces no error. The file still exists, still parses, still renders — the on-chain anchor simply no longer resolves. Detection is downstream (verification query fails) and often much later.
+
+### Legacy Names
+
+Some objects anchored prior to v1.2.0 ratification use a **non-canonical first field** (e.g., `strategy.plan.claims-engine-dogfood-plan.v0.1.0` where `strategy` is neither a canonical relevance nor type). These legacy names are preserved as historical record — the ledger anchor is the authoritative identity of the object, and the on-chain record cannot be retroactively corrected without invalidating the anchor.
+
+Going forward (v1.2.0+), all new anchored objects must use canonical `[relevance].[type].[subject].vX.Y.Z`. Legacy objects are grandfathered and should be cross-indexed to canonical names in the artifact registry (if applicable) but never renamed on-chain.
+
+---
+
+## Controlled Vocabularies (v1.3.0)
+
+Beyond the KOI Name grammar, KOI objects carry **classification properties** whose allowed values are controlled vocabularies (L0). These vocabularies are canonical here so that the same value means the same thing across the KOI Repo, the BizDev pipeline, the Organizations DB, and any published record.
+
+- **Vertical** — the market-context taxonomy. The canonical v1 list (9 values, Title Case), the retirements, and the historical alias map for backfill are ratified in [`docs/vertical-canonical-v1.md`](./docs/vertical-canonical-v1.md). This supersedes the legacy ALL-CAPS 8-option KOI list and the divergent 10-option BizDev list.
+- **Relevance** — `core` / `relevant` / `background` (see §Relevance Levels).
+- **Access** — the five tiers (see §Access Levels).
+- **Publication** — the publication targets (see §Publication).
+
+**Vocabulary governance.** A controlled vocabulary changes by the same propose → pilot → ratify process as the naming convention. New values, retirements, and casing conventions are recorded in the vocabulary's doc under `docs/`, with an alias map whenever a change requires backfill. Casing is **Title Case** for all vocabulary values unless a value is a proper acronym.
+
+**Where the ground truth lives.** A controlled vocabulary's authoritative source is its `docs/` file in this repo. Storage surfaces (Notion option-sets, BizDev fields, RDF class instances) are downstream *mirrors* of that source and are reconciled to it during metadata upgrades — never the other way around.
+
+---
+
+## Governance Process
+
+Changes to this naming convention follow the process outlined in [CONTRIBUTING.md](./CONTRIBUTING.md):
+
+1. **Propose** a new type, relevance level, or naming change via GitHub Issue or PR.
+2. **Pilot** the proposed change in practice (minimum 2 weeks, minimum 3 objects using the new convention).
+3. **Review** pilot results with maintainer and at least one other contributor.
+4. **Ratify** via pull request merged to main.
+
+---
+
+## Changelog
+
+See [changelog.md](./changelog.md) for the full record of changes.

--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,27 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
 
 ---
 
+## [1.3.0] - Proposed (pending governance-call ratification)
+
+> Stacks on the pending v1.2.0 PR (`claude/v1.2.0-types-anchoring-examples`), which is not yet merged to `main`. Ratify v1.2.0 first, or ratify the two together. No breaking changes; all existing KOI names and Access values remain valid.
+
+### Added
+
+- **Five-tier Access scheme** — reconciles the canonical Access levels with the RegenOS / vault / federation access model. `Public / Knowledge Commons / Internal` are unchanged; **`Partner`** (close-collaborator tier) and **`Personal`** (sovereignty floor, never federated/published) are added. Access declared orthogonal to Relevance and to Publication, with a mapping table to the workspace `access:` values.
+- **RID as a first-class metadata property** — `orn:regen.<entity-class>:<context>/<reference>`; minted on creation, stable across renames and version bumps, emitted with every published record, and the join key between KOI Name and ledger anchor. New §Resource Identifier (RID).
+- **Publication property** — the per-surface publish decision (`Public Web / Open Index / Commons Trove / Partner Space`), each gated by a minimum Access tier, publish-by-decision-not-default, never set on `Personal`, logged per emit. Distinct from `Status` (editorial) and `Access` (sensitivity). New §Publication. This is the machine-checkable enforcement point for the Sensitivity and Reference-Accessibility gates.
+- **Canonical Vertical controlled vocabulary** ratified in `docs/vertical-canonical-v1.md` — 9 Title-Case values, 2 retirements (`PUBLIC SECTOR`, `General Tech Provider` → Actor Type on Organizations DB), and a historical alias map for backfill. Supersedes the legacy ALL-CAPS 8-option KOI list and the 10-option BizDev list. New §Controlled Vocabularies establishes `docs/` as vocabulary ground truth.
+- **Proposal doc** `meta.reflection.koi-publishing-spine-metadata.v0.1.0.md` with semantic-gap analysis, examples, tradeoffs, cross-surface rollout, and pilot plan.
+- `docs/semantic-naming-properties.md` property templates (Notion / Google Docs / GitHub) extended with `RID`, `Publication`, and five-tier `Access`.
+
+### Notes
+
+- Manifesto version bumped v1.2.0 → v1.3.0; `KOI.regen-naming-convention-manifesto.v1.2.0.md` preserved as historical record.
+- The surface-specific metadata-upgrade execution runbook (Notion field IDs, DDL, backfill scripts, sequencing) is maintained as an **Internal** KOI object, not in this public repo, per the pre-push sensitivity gate. This changelog governs the convention; the runbook governs execution.
+- Pilot evidence (≥2 weeks, ≥3 objects across the new tiers) to be recorded in the proposal doc before merge.
+
+---
+
 ## [1.2.0] - 2026-04-21
 
 ### Added

--- a/docs/semantic-naming-properties.md
+++ b/docs/semantic-naming-properties.md
@@ -22,14 +22,19 @@ Use a Notion Database to represent KOI Objects with structured properties:
 |-------------|--------------------------------------------------------|
 | Title       | RegenOS Overview — Unified Operating System for RND PBC |
 | KOI Name    | core.strategy.regen-os-overview.v0.1.0                 |
+| RID         | orn:regen.artifact:koi/core.strategy.regen-os-overview.v0.1.0 |
 | Relevance   | core                                                   |
 | Type        | strategy                                               |
 | Subject     | regen-os-overview                                      |
 | Version     | v0.1.0                                                 |
 | Status      | draft                                                  |
 | Access      | Internal                                               |
+| Publication | (none)                                                 |
 | Ready for AI| yes                                                    |
 
+- **Access** is one of the five canonical tiers: `Public / Knowledge Commons / Partner / Internal / Personal` (manifesto §Access Levels).
+- **RID** is the durable resolvable identifier (manifesto §Resource Identifier); it is stable across renames and version bumps.
+- **Publication** is the set of approved external surfaces — `Public Web / Open Index / Commons Trove / Partner Space` — or empty (manifesto §Publication). Empty means published nowhere; it is gated by Access.
 - **Search Tips**: Notion prioritizes title search. Use filters to query metadata.
 - **Linking**: Canonical versions can link to Google Docs, GitHub, or exported JSON.
 
@@ -43,12 +48,14 @@ Example metadata block:
 ```
 Title: RegenOS Overview — Unified Operating System for RND PBC
 KOI Name: core.strategy.regen-os-overview.v0.1.0
+RID: orn:regen.artifact:koi/core.strategy.regen-os-overview.v0.1.0
 Relevance: core
 Type: strategy
 Subject: regen-os-overview
 Version: v0.1.0
 Status: draft
 Access: Internal
+Publication: (none)
 ```
 
 ---
@@ -61,12 +68,14 @@ Access: Internal
 ```yaml
 ---
 koi_name: core.strategy.regen-os-overview.v0.1.0
+rid: orn:regen.artifact:koi/core.strategy.regen-os-overview.v0.1.0
 relevance: core
 type: strategy
 subject: regen-os-overview
 version: v0.1.0
 status: draft
-access: Internal
+access: Internal          # Public | Knowledge Commons | Partner | Internal | Personal
+publication: []           # any of: Public Web, Open Index, Commons Trove, Partner Space
 ready_for_ai: true
 ---
 ```

--- a/docs/vertical-canonical-v1.md
+++ b/docs/vertical-canonical-v1.md
@@ -1,0 +1,75 @@
+# Canonical Vertical List (v1)
+
+**Status:** Ratified vocabulary (proposed for merge with manifesto v1.3.0)
+**Applies to:** KOI Repo `Vertical`, BizDev pipeline `Vertical`, and any published record's market-context tag
+**Casing:** Title Case (no ALL CAPS, no lowercase)
+
+The **Vertical** property tracks *market context* — the market or program space an object relates to. It is not an actor type and not an instrument type. This list replaces two divergent option sets (the legacy KOI 8-option ALL-CAPS list and the BizDev 10-option mixed-case list) with one shared 9-item vocabulary.
+
+---
+
+## Canonical values (v1)
+
+| # | Canonical Name | Definition |
+|---|---|---|
+| 1 | **Insetting & Sustainable Supply Chain** | Corporate value-chain decarbonization and supply-chain integrity programs. |
+| 2 | **Water Positive** | Water stewardship accounting, net-positive water commitments, water-risk programs. |
+| 3 | **Eco Credits** | Full class of ecological credit instruments where buyers purchase units of ecological impact, outcomes, or actions — covers carbon, biodiversity, water, and stewardship credits. |
+| 4 | **Non-Carbon Compliance Markets** | Regulatory-mandated markets for non-carbon environmental compliance (water quality, nutrients, wetlands, etc.). |
+| 5 | **Nature & Biodiversity Finance** | Nature-related financial disclosure, biodiversity net-gain markets, TNFD-linked instruments. |
+| 6 | **Impact Financing** | Broad category: blended finance, impact investing, concessional capital, first-loss tranches — not debt-instrument-specific. |
+| 7 | **Green Bonds** | Debt-based financial instrumentation: green bonds, sustainability-linked bonds, labeled bond markets. |
+| 8 | **Reporting** | Ecological and sustainability reporting standards (ESG, SDG, TNFD, SBTN, etc.) — claims that do not necessarily reach financial-grade verification; distinct from payment and credit systems. |
+| 9 | **Grant Programs & Certifications** | Non-market funding mechanisms: grants, philanthropic programs, ecolabels, standards certifications. |
+
+### Key conceptual distinctions
+
+- **Eco Credits vs financial instruments.** Eco Credits are the underlying ecological asset (units of impact). Green Bonds and Impact Financing are vehicles that monetize, bundle, or reference those units. Different layers — Vertical tracks market context, not instrument type.
+- **Impact Financing vs Green Bonds.** Impact Financing is broad (equity, quasi-equity, blended, concessional). Green Bonds are specifically debt-based. Distinct because the financing mechanism differs materially.
+- **Reporting vs crediting.** Reporting standards (ESG, TNFD, SDG) operate at a different claims-maturity level than eco-credit or compliance markets and need not reach financial-grade verification. This distinction is load-bearing for how Regen positions its verification infrastructure.
+
+---
+
+## Retirements
+
+| Retired option | Was in | Reason |
+|---|---|---|
+| `PUBLIC SECTOR` | KOI Vertical | Actor-type axis bleeding into Vertical. Retire here; lives on the Organizations DB as **Actor Type**. |
+| `General Tech Provider` | BizDev Vertical | Not a market vertical — an actor type / service offering. Retire from Vertical. |
+
+---
+
+## Historical alias map (for backfill)
+
+Legacy values remain valid during migration; sensors and new objects use canonical names going forward. Mapping for automated normalization:
+
+```
+INSETTING                                            → Insetting & Sustainable Supply Chain
+WATER POSITIVE                                       → Water Positive
+Water Positive Accounting                            → Water Positive
+CARBON CREDITS                                       → Eco Credits
+ECOCREDITS                                           → Eco Credits
+Eco Credit Market                                    → Eco Credits
+IMPACT FINANCING                                     → Impact Financing
+SDG REPORTING                                        → Reporting
+regulated markets                                    → Non-Carbon Compliance Markets
+Environmental Regulation and Compliance (non carbon) → Non-Carbon Compliance Markets
+Non-Carbon Compliance Markets                        → Non-Carbon Compliance Markets (no change)
+Nature Related Financial & ESG                       → Nature & Biodiversity Finance
+Biodiversity Market                                  → Nature & Biodiversity Finance
+Bond Markets                                         → Green Bonds
+Grant Programs & Certifications                      → Grant Programs & Certifications (no change)
+PUBLIC SECTOR                                        → [retire — remap to Actor Type on Organizations DB]
+General Tech Provider                                → [retire — remap to Actor Type on Organizations DB]
+```
+
+---
+
+## Migration procedure (surface-agnostic)
+
+1. Add the 9 canonical values to each `Vertical` field (KOI Repo, BizDev), keeping legacy values present as aliases.
+2. Backfill existing rows via the alias map above (scripted where possible; by attrition otherwise).
+3. Once no rows reference a legacy value, remove the legacy option.
+4. `PUBLIC SECTOR` and `General Tech Provider` rows are remapped to **Actor Type** on the Organizations DB, not to a Vertical.
+
+Surface-specific execution (field IDs, DDL, sequencing) lives in the internal metadata-upgrade runbook, not in this public vocabulary doc.

--- a/meta.reflection.koi-publishing-spine-metadata.v0.1.0.md
+++ b/meta.reflection.koi-publishing-spine-metadata.v0.1.0.md
@@ -1,0 +1,123 @@
+---
+koi_name: meta.reflection.koi-publishing-spine-metadata.v0.1.0
+relevance: core
+type: reflection
+subject: koi-publishing-spine-metadata
+version: v0.1.0
+status: draft
+access: Public
+format: property-based
+proposes: manifesto v1.3.0
+stacks_on: v1.2.0 (claude/v1.2.0-types-anchoring-examples)
+---
+
+# Proposal — KOI Publishing-Spine Metadata (manifesto v1.3.0)
+
+**Semver impact:** minor (`v1.2.0 → v1.3.0`). Expands existing conventions; **no breaking change** — every existing KOI Name and Access value remains valid.
+
+**Format:** property-based (Notion / YAML / JSON metadata fields), consistent with `docs/semantic-naming-properties.md`.
+
+**Stacks on:** the pending v1.2.0 PR (`claude/v1.2.0-types-anchoring-examples`), which itself is not yet merged to `main`. Ratify v1.2.0 first, or ratify the two together.
+
+---
+
+## 1. Why this proposal
+
+KOI has become the de-facto spine for RND and close-collaborator knowledge creation, and it is now being asked to serve as the canonical repository behind pluggable publishing surfaces (public web, the Murmurations/Catalist ecosystem index, commons and partner troves). Three metadata gaps block that role, and one ratified-but-undeployed vocabulary decision is still causing cross-database join failures:
+
+1. **Access cannot express partner or personal.** The canonical scheme is three tiers (Public / Knowledge Commons / Internal). The rest of the ecosystem uses five (public / commons / partner / internal / personal). The two missing tiers are exactly the ones cooperative publishing needs: **Partner** (the close-collaborator tier) and **Personal** (the sovereignty floor that gates must exclude).
+2. **Identity is decorative.** The KOI Name is a human-legible, version-mutable label — not a resolvable identity. Published records need a durable identifier that survives publication and round-trips back to the canonical object.
+3. **There is no publish decision.** `Status: published` conflates "internally finished" with "cleared to emit externally," and there is no representation of *which* surface an object is approved for. Publication is currently a matter of reviewer memory, not a machine-checkable property.
+4. **The canonical Vertical vocabulary was agreed but never deployed.** The 9-item Title-Case list (KOI × BizDev normalization sprint, 2026-05-04) still has not replaced the legacy 8-option ALL-CAPS KOI list, so cross-DB rollups silently break.
+
+## 2. What this proposal changes (manifesto v1.3.0)
+
+### Change A — Five-tier Access
+Reconcile the canonical Access scheme with the RegenOS / vault / federation model: **Public · Knowledge Commons · Partner · Internal · Personal.** Public / Knowledge Commons / Internal are unchanged; Partner and Personal are added. Access is declared orthogonal to Relevance and to Publication. *(Manifesto §Access Levels.)*
+
+### Change B — RID as a first-class property
+Promote the **RID** (`orn:regen.<entity-class>:<context>/<reference>`) to a required metadata property: minted on creation, stable across renames and version bumps, emitted with every published record as the durable back-reference, and the join key between KOI Name and ledger anchor. *(Manifesto §Resource Identifier.)*
+
+### Change C — Publication property (the publish flag)
+Add a **Publication** property: a set of zero or more approved publication targets (Public Web · Open Index · Commons Trove · Partner Space), each gated by a minimum Access tier, each a separate logged decision, publish-by-decision-not-default, and never set on a Personal object. This is the machine-checkable enforcement point for the Sensitivity and Reference-Accessibility gates. *(Manifesto §Publication.)*
+
+### Change D — Ratify the canonical Vertical vocabulary
+Ratify the 9-value Title-Case Vertical list, its two retirements, and its historical alias map into [`docs/vertical-canonical-v1.md`](./docs/vertical-canonical-v1.md), and establish `docs/` as the ground-truth home for controlled vocabularies (storage surfaces are downstream mirrors). *(Manifesto §Controlled Vocabularies.)*
+
+## 3. Semantic gaps resolved
+
+| Gap | Before | After |
+|---|---|---|
+| Partner-scoped publication has no state | Folded awkwardly into "Knowledge Commons" | First-class `Partner` Access + `Partner Space` Publication target |
+| Personal exclusion relies on memory | No `Personal` tier | Explicit `Personal` floor; gates exclude mechanically |
+| No resolvable identity | KOI Name (mutable label) only | `RID` property, round-trip guaranteed |
+| "Published" is ambiguous | `Status: published` | `Status` (editorial) + `Publication` (per-surface, gated) separated |
+| Vertical joins break | 8 ALL-CAPS vs 10 mixed | One 9-value Title-Case list + alias map |
+
+## 4. Examples (property-based)
+
+```yaml
+# A partner-scoped analysis, approved for a named partner trove
+koi_name: relevant.analysis.partner-mangrove-basket-fit.v0.2.0
+rid: orn:regen.artifact:koi/relevant.analysis.partner-mangrove-basket-fit.v0.2.0
+relevance: relevant
+access: Partner
+publication: [Partner Space]
+vertical: [Eco Credits]
+```
+
+```yaml
+# A public overview, approved for the open ecosystem index
+koi_name: core.overview.regen-registry-public.v1.0.0
+rid: orn:regen.artifact:koi/core.overview.regen-registry-public.v1.0.0
+relevance: core
+access: Public
+publication: [Public Web, Open Index]
+vertical: [Eco Credits, Reporting]
+```
+
+```yaml
+# A personal working note — never published
+koi_name: background.notes.weekly-scratch.v0.1.0
+rid: orn:regen.artifact:koi/background.notes.weekly-scratch.v0.1.0
+relevance: background
+access: Personal
+publication: []      # P4 — Personal never publishes
+```
+
+## 5. Anticipated tradeoffs
+
+- **More fields to set.** Two new tiers + two new properties raise per-object entry cost. Mitigation: auto-classification (koi-repo-saver) proposes defaults; humans confirm. `Publication` defaults to empty (nothing publishes without an explicit decision), so the safe default is free.
+- **Migration touches multiple surfaces.** Access, Vertical, RID and Publication must be reflected across Notion (KOI Repo, Organizations DB, BizDev), Google Docs metadata blocks, GitHub frontmatter, and the publication boundary. See §6.
+- **RID resolution isn't live yet.** The format is fixed now so identifiers are stable; resolution is manual until the KOI resolver ships. No re-minting later.
+- **Access-tier proliferation risk.** Held at five (matching the ecosystem model); finer distinctions stay project-local within `Internal`.
+
+## 6. Cross-surface rollout (convention level)
+
+These metadata changes must be reflected consistently on **every KOI surface**, reconciled to the `docs/` ground truth:
+
+1. **Notion KOI Repo** — expand `Access` to five options; add `RID` (text) and `Publication` (multi-select) properties; migrate `Vertical` to the canonical 9 with legacy aliases retained until backfilled.
+2. **Related Notion DBs** — the `Vertical` change also lands on the BizDev pipeline; retirements (`PUBLIC SECTOR`, `General Tech Provider`) remap to **Actor Type** on the Organizations DB.
+3. **Google Docs / GitHub frontmatter** — add `rid`, `publication`, and the five-tier `access` to the property templates in [`docs/semantic-naming-properties.md`](./docs/semantic-naming-properties.md).
+4. **Publication boundary** — the RID is the identifier emitted to published records (Murmurations/Catalist and other AppViews); the `Publication` property is the gate ("labeler") that decides what leaves.
+
+> The **surface-specific execution runbook** (field IDs, Notion DDL, backfill scripts, sequencing, and any partner-pilot specifics) is maintained as an **Internal** KOI object, not in this public repo, per the pre-push sensitivity gate. This proposal governs the *convention*; the runbook governs the *execution*.
+
+## 7. Pilot plan (CONTRIBUTING.md: ≥2 weeks, ≥3 objects)
+
+Pilot the five-tier Access + RID + Publication properties on at least three live objects spanning the new tiers before ratification:
+
+1. A **Partner**-tier object approved for `Partner Space` (close-collaborator pilot — the natural first real case).
+2. A **Public** object approved for `Public Web` + `Open Index`.
+3. A **Personal** object carrying an RID and empty Publication (proves the exclusion path).
+
+Success: each object carries a stable RID; the Access→Publication gate rejects every disallowed combination; and the canonical Vertical values join cleanly across KOI Repo and BizDev. Record pilot findings in this doc before merge.
+
+## 8. Ratification checklist
+
+- [ ] v1.2.0 PR ratified/merged (or ratified together with this)
+- [ ] Governance-call review (RND + Foundation) of the five-tier Access reframe
+- [ ] KOI substrate maintainer: RID format + resolver alignment with KOI substrate
+- [ ] BizDev + KOI stewards: canonical Vertical sign-off (the long-pending gate) + KOI usage audit
+- [ ] Pilot evidence recorded (§7)
+- [ ] Manifesto v1.3.0 + `docs/vertical-canonical-v1.md` + `docs/semantic-naming-properties.md` merged; changelog updated


### PR DESCRIPTION
## Summary

Adds the metadata layer that lets KOI serve as the canonical spine behind pluggable publishing surfaces for RND + close collaborators (proposal: `meta.reflection.koi-publishing-spine-metadata.v0.1.0`).

**Semver:** minor (`v1.2.0 → v1.3.0`). No breaking changes — every existing KOI Name and Access value stays valid.

**Base:** this PR stacks on the still-unmerged `claude/v1.2.0-types-anchoring-examples` (main is at v1.1.0). Ratify/merge v1.2.0 first, or ratify the two together.

## What changes

- **Five-tier Access** — adds `Partner` (the close-collaborator tier) and `Personal` (sovereignty floor), reconciling the canonical scheme with the RegenOS / vault / federation access model. Declared orthogonal to Relevance and Publication.
- **RID** promoted to a first-class resolvable identity property (`orn:regen.<class>:<context>/<reference>`) — stable across renames/version bumps, emitted with every published record, join key between KOI Name and ledger anchor.
- **Publication** property — the per-surface, Access-gated publish decision (`Public Web / Open Index / Commons Trove / Partner Space`), separated from editorial `Status`. The machine-checkable enforcement point for the Sensitivity + Reference-Accessibility gates.
- **Canonical Vertical vocabulary** ratified in `docs/vertical-canonical-v1.md` (9 Title-Case values + 2 retirements + alias map); `docs/` established as controlled-vocabulary ground truth. Supersedes the legacy ALL-CAPS 8-option list and unblocks cross-DB rollups.
- Notion / Google Docs / GitHub property templates extended with RID, Publication, five-tier Access.

## Files

- `KOI.regen-naming-convention-manifesto.v1.3.0.md` (v1.2.0 preserved)
- `docs/vertical-canonical-v1.md`
- `meta.reflection.koi-publishing-spine-metadata.v0.1.0.md`
- `changelog.md`, `docs/semantic-naming-properties.md`

## Not in this PR (by design)

The surface-specific execution runbook (Notion field IDs, DDL, backfill scripts, sequencing, partner-pilot specifics) is maintained as an **Internal** KOI object, not this public repo, per the pre-push sensitivity gate. This PR governs the *convention*; the runbook governs *execution*.

## Ratification checklist

- [ ] v1.2.0 PR ratified/merged (or ratified together with this)
- [ ] Governance-call review of the five-tier Access reframe
- [ ] KOI substrate maintainer: RID format + resolver alignment
- [ ] BizDev + KOI stewards: canonical Vertical sign-off (long-pending gate) + KOI usage audit
- [ ] Pilot evidence recorded (≥2 weeks, ≥3 objects across the new tiers)

🤖 Generated with [Claude Code](https://claude.com/claude-code)