### PR TITLE
Schema governance boundary with regen-data-standards (v1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,17 @@ Welcome to the **KOI (Knowledge Organization Infrastructure) Governance Reposito
 
 KOI is our collective infrastructure for creating coherent, transparent, and actionable knowledge objects within Regen Network. By maintaining semantic clarity, we enable decentralized teams, AI agents, and community participants to collaborate meaningfully.
 
+### Scope — one of two adjacent schema domains
+
+Regen governs two interdependent schema sets:
+
+- **This repository** governs **non-registry operational and knowledge schemas** — RegenOS, Compass, work coordination, decisions, specs — plus the cross-cutting properties that apply org-wide: Relevance, Type, Vertical, Access tier, Publication decision, the `orn:regen.*` RID namespace, and ledger-anchoring discipline.
+- **[`regen-data-standards`](https://github.com/regen-network/regen-data-standards)** governs **registry-system schemas** — projects, credit classes, methodologies, claims, attestations, impacts, taxonomies — as LinkML sources published under `https://framework.regen.network/schema/`.
+
+*Does the schema describe an object the ecocredit registry issues, holds, or verifies?* If yes, it belongs to `regen-data-standards`. If it describes how Regen itself works, decides, or publishes, it belongs here.
+
+The boundary contract between them — including how cross-domain references travel — is **[`docs/schema-governance-boundary-v1.md`](./docs/schema-governance-boundary-v1.md)**.
+
 ---
 
 ## 📌 Key Documents
@@ -21,6 +32,7 @@ KOI is our collective infrastructure for creating coherent, transparent, and act
 |----------|---------|
 | [`KOI.regen-naming-convention-manifesto.v1.2.0.md`](./KOI.regen-naming-convention-manifesto.v1.2.0.md) | **Current manifesto.** Defines the KOI semantic naming schema, versioning practices, object types, ledger anchoring discipline, and governance process. |
 | [`examples/`](./examples/) | Worked examples of each object type (v1.2.0 pilot set + more). |
+| [`docs/schema-governance-boundary-v1.md`](./docs/schema-governance-boundary-v1.md) | **Boundary contract with [`regen-data-standards`](https://github.com/regen-network/regen-data-standards).** Which repo governs which schemas, how cross-domain references travel as RIDs, and the seam-change protocol. |
 | [`CONTRIBUTING.md`](./CONTRIBUTING.md) | Explains how to propose, pilot, and ratify changes to the KOI naming schema. |
 | [`changelog.md`](./changelog.md) | Tracks all approved changes and updates to the naming conventions. |
 | [`KOI.regen-naming-convention-manifesto.v1.1.0.md`](./KOI.regen-naming-convention-manifesto.v1.1.0.md) | Previous version (archived). |

--- a/docs/schema-governance-boundary-v1.md
+++ b/docs/schema-governance-boundary-v1.md
@@ -1,0 +1,70 @@
+# Schema Governance Boundary (v1)
+
+**Status:** Proposed — pending governance-call ratification (stacks with manifesto v1.2.0 / v1.3.0)
+**Applies to:** `regen-network/koi-gov` and `regen-network/regen-data-standards`
+**Canonical home:** this file. `regen-data-standards` points here; it does not restate the contract.
+
+Regen governs **two adjacent and interdependent schema sets**. This document declares which repository has authority over which, how the two reference each other, and what happens at the seam.
+
+The seam is not new. Both repositories already reach for each other — `Claim.supersedes` accepts ORN RIDs, `Attestation.hasReviewer` requires "a registered identity (KOI entity URI and/or wallet address)", and koi-gov v1.3.0 defines exactly that identifier. This document makes the existing connection explicit and governed.
+
+---
+
+## The two domains
+
+| | **Registry system** | **Non-registry operational + knowledge** |
+|---|---|---|
+| **Authority** | [`regen-data-standards`](https://github.com/regen-network/regen-data-standards) | `koi-gov` (this repo) |
+| **Namespace** | `https://framework.regen.network/schema/` (prefix `rfs:`) — dereferenceable | `orn:regen.<entity-class>:<context>/<reference>` |
+| **Form** | LinkML sources → RDF / JSON-LD / TTL | Markdown manifesto + controlled vocabularies |
+| **Covers** | Projects, credit classes, methodologies, crediting programs, registries, credit protocols, claims, attestations, impacts, SDGs, geometry, taxonomies | RegenOS, Compass, work coordination, knowledge objects, decisions, specs, memos, analyses, registries-of-artifacts |
+| **Governs** | Structure and semantics of registry data | Naming, Relevance, Type, Vertical, Access tier, Publication decision, RID identity, ledger-anchoring discipline |
+
+**One-line test:** *does the schema describe an object the ecocredit registry issues, holds, or verifies?* If yes, `regen-data-standards`. If it describes how Regen itself works, decides, or publishes, `koi-gov`.
+
+---
+
+## Rules
+
+**SGB-1 — Domain assignment.** Every schema has exactly one governing repository, assigned by the test above. Ambiguity resolves toward `regen-data-standards` when the object is registry-facing, toward `koi-gov` when it is organization-facing.
+
+**SGB-2 — No cross-domain redefinition.** Neither repository redefines a class the other owns. koi-gov does not define `Claim`; `regen-data-standards` does not define Access tiers. Where a domain needs the other's concept, it **references** it.
+
+**SGB-3 — Reference by identifier, across a shared RID space.** Registry-domain objects are referenced by IRI under `rfs:`. Non-registry objects are referenced by ORN under `orn:regen.*`. Both are valid RIDs under RID v3, which spans URI schemes (`http`, `https`) and ORNs alike. **No translation layer is required — the RID space is the join.** A slot that may hold either declares `range: uriorcurie`.
+
+**SGB-4 — Cross-cutting properties are koi-gov's, in both domains.** Access tier, Publication target, RID identity, and ledger-anchoring discipline are organization-wide governance concerns. They apply to registry artifacts too — a credit-class schema published to an external surface is a Publication decision under manifesto §Publication (P1: publish-by-decision, not by default), regardless of which repo defines its structure. `regen-data-standards` does not restate these rules; it inherits them.
+
+**SGB-5 — One anchoring mechanism.** Both domains anchor through Regen Ledger `x/data` `MsgAnchor`. `Claim.contentHash` (BLAKE2b-256) + `Claim.dataIri` are the registry-domain expression of the same mechanism the manifesto §Ledger Anchoring describes for KOI objects. The canonical/manifest/receipt triad and the rename discipline apply to both.
+
+**SGB-6 — Change coordination at the seam.** A change to any slot that carries a cross-domain reference (see the inventory below) requires notice to the other repository before merge. Adding a new cross-domain reference requires adding it to that inventory.
+
+**SGB-7 — The `orn:regen.*` namespace is governed here.** Its grammar is manifesto §RID. Entity-classes are enumerated in this repository. Any implementation minting `orn:regen.*` identifiers — including the [`regen-koi-mcp`](https://www.npmjs.com/package/regen-koi-mcp) client and Regen's internal knowledge-base tooling — conforms to that grammar or is non-conformant.
+
+---
+
+## Cross-domain reference inventory
+
+Existing seam points, as of 2026-08-07. Changes to these are SGB-6 events.
+
+| Slot | Repo | Range | Points at |
+|---|---|---|---|
+| `Claim.supersedes` | data-standards | `uriorcurie` — *"Accepts full IRIs and CURIE-form identifiers such as ORN RIDs (orn:...)"* | either domain |
+| `Attestation.attestsClaim` | data-standards | *"by RID or IRI"* | either domain |
+| `Attestation.hasReviewer` | data-standards | `Entity` — *"Must have a registered identity (KOI entity URI and/or wallet address)"* | `orn:regen.entity:org/<slug>` |
+| `Claim.dataIri` | data-standards | `uri` — Regen Data Module IRI from content hash | on-chain anchor (shared, SGB-5) |
+| RID property | koi-gov | `orn:regen.<entity-class>:<context>/<reference>` | may reference `rfs:` classes |
+
+---
+
+## Open items
+
+1. **Enumerate the `orn:regen.*` entity-classes.** The manifesto gives the grammar and three examples (`document`, `artifact`, `entity`). The [`regen-koi-mcp`](https://www.npmjs.com/package/regen-koi-mcp) client independently carries six (`document`, `ontology`, `methodology`, `credit`, `agent`, `project`). Two of those — `methodology` and `project` — name **registry-domain** objects, which under SGB-1/SGB-2 are `rfs:` classes and should be referenced by IRI rather than ORN-minted. Ratify the canonical entity-class list and align implementations to it.
+2. **Decide whether `rfs:` classes get ORN aliases.** SGB-3 says they do not need them. Confirming this closes the question for implementers.
+3. **Upstream registration.** `orn:regen.*` is not yet registered in [`DynamicalSystemsGroup/rid-registry`](https://github.com/DynamicalSystemsGroup/rid-registry), the ORN type registry for KOI-net, whose README describes itself as coordinating RID types rather than authoritatively defining them. Once items 1–2 are ratified, register the namespace there with a pointer to this document — and offer the governance model itself (access tiers, publication-by-decision, RID-as-identity, anchoring) as a contribution to that coordination effort, should it be useful.
+
+## Related
+
+- `KOI.regen-naming-convention-manifesto.v1.3.0.md` — §RID, §Publication, §Ledger Anchoring, §Access
+- `docs/vertical-canonical-v1.md` — the Vertical controlled vocabulary (shared with the BizDev pipeline)
+- `regen-data-standards/schema/README.md` — LinkML sources and generation
+- `regen-data-standards/schema/GOVERNANCE.md` — the reciprocal pointer to this document


### PR DESCRIPTION
Declares which repository governs which schemas, and the contract at the seam.

**Stacked on #4** (v1.3.0), which is stacked on #3 (v1.2.0). This document depends on §RID, introduced in v1.3.0. Merge order: #3 → #4 → this.

## The two domains

| | Authority | Namespace |
|---|---|---|
| **Registry system** — projects, credit classes, methodologies, claims, attestations, impacts, taxonomies | [`regen-data-standards`](https://github.com/regen-network/regen-data-standards) | `https://framework.regen.network/schema/` |
| **Non-registry operational + knowledge** — RegenOS, Compass, work coordination, decisions, specs | this repo | `orn:regen.<entity-class>:<context>/<reference>` |

Domain test: *does the schema describe an object the ecocredit registry issues, holds, or verifies?* If yes it belongs to `regen-data-standards`; if it describes how Regen itself works, decides, or publishes, it belongs here.

## Rules SGB-1..7

Domain assignment · no cross-domain redefinition · reference-by-RID · cross-cutting properties (Access, Publication, RID, anchoring) are governed here **in both domains** · one shared `x/data` `MsgAnchor` mechanism · seam-change notice · `orn:regen.*` is governed here.

## Two things worth review

**No translation layer is needed.** RID v3 spans URI schemes *and* ORNs, so an `rfs:` IRI and an `orn:regen.*` ORN are both already valid RIDs. The shared RID space is the join; a slot that may hold either declares `range: uriorcurie` — as `Claim.supersedes` already does.

**The seam predates this document.** `Claim.supersedes` accepts ORN RIDs, `Attestation.attestsClaim` takes "RID or IRI", and `Attestation.hasReviewer` requires a "KOI entity URI" — which manifesto §RID defines as `orn:regen.entity:org/<slug>`. This records an existing connection rather than creating one. Four seam points are inventoried with an SGB-6 notice protocol attached.

## Open items (in the doc, for the governance call)

1. Ratify the canonical `orn:regen.*` entity-class list. Applying SGB-1/SGB-2 surfaced that two entity-classes carried by the `regen-koi-mcp` client — `methodology` and `project` — name registry-domain objects and belong under `rfs:` as IRIs.
2. Confirm `rfs:` classes need no ORN aliases.
3. Register `orn:regen.*` upstream in [`DynamicalSystemsGroup/rid-registry`](https://github.com/DynamicalSystemsGroup/rid-registry) once 1–2 ratify.

Companion PR on the registry side: `regen-network/regen-data-standards` adds `schema/GOVERNANCE.md` pointing here. **Merge this first** — that pointer targets `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)